### PR TITLE
Add Dockerfiles for Go CI prereqs

### DIFF
--- a/src/cbl-mariner/1.0.20211027/amd64/Dockerfile
+++ b/src/cbl-mariner/1.0.20211027/amd64/Dockerfile
@@ -1,0 +1,16 @@
+FROM cblmariner.azurecr.io/base/core:1.0.20211027
+
+# Install dependencies needed to build, test, and longtest Go.
+RUN tdnf install -y \
+        binutils \
+        ca-certificates-microsoft \
+        gcc \
+        git \
+        glibc \
+        glibc-devel \
+        iana-etc \
+        kernel-headers \
+        mercurial \
+        openssl-devel \
+        powershell \
+    && tdnf clean all

--- a/src/ubuntu/18.04/amd64/Dockerfile
+++ b/src/ubuntu/18.04/amd64/Dockerfile
@@ -1,0 +1,38 @@
+FROM ubuntu:18.04
+
+# Based on https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/5c627c7ceeb94a58033cdc927f349b6ae8ffe333/src/ubuntu/18.04/amd64/Dockerfile
+# Then modified to remove some unnecessary tools and include dependencies for Go long tests.
+
+# Install the base toolchain we need to build anything (clang, cmake, make and the like).
+RUN apt-get update \
+    && apt-get install -y \
+        clang-3.9 \
+        gdb \
+        liblldb-3.9-dev \
+        lldb-3.9 \
+        llvm-3.9 \
+        locales \
+        make \
+        python-lldb-3.9 \
+        sudo \
+        wget \
+    && rm -rf /var/lib/apt/lists/* \
+    && wget https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.tar.gz \
+    && tar -xf cmake-3.10.2-Linux-x86_64.tar.gz --strip 1 -C /usr/local \
+    && rm cmake-3.10.2-Linux-x86_64.tar.gz
+
+# Install tools used by the AzDO build automation.
+RUN apt-get update \
+    && apt-get install -y \
+        git \
+        nodejs \
+        npm \
+        tar \
+        zip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Go long test prerequisites.
+RUN apt-get update \
+    && apt-get install -y \
+        mercurial \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Add initial Dockerfiles for Go CI prereq images. No automation to build them, yet.

Building locally with `docker build . -t mariner`, for example, makes an image that works for me for build and short tests. Long tests (running the `linux-amd64-longtest` builder) fail with this error:

```
--- FAIL: TestScript (0.01s)
--- FAIL: TestScript/mod_get_direct (1.49s)
script_test.go:257:
# Regression test for golang.org/issue/34092: with an empty module cache,
# 'GOPROXY=direct go get golang.org/x/tools/gopls@master' did not correctly
# resolve the pseudo-version for its dependency on golang.org/x/tools. (1.492s)
> [short] skip
            > [!net] skip
            > [!exec:git] skip
            > env GO111MODULE=on
            > env GOPROXY=direct
            > env GOSUMDB=off
            > go list -m cloud.google.com/go@master
            [stderr]
            go: cloud.google.com/go@master: invalid version: unknown revision master
            [exit status 1]
            FAIL: testdata/script/mod_get_direct.txt:13: unexpected command failure

FAIL
FAIL    cmd/go  266.568s
```

But, we don't need long tests to work in our first iteration here. It also might just be a problem with my environment, anyway.