### PR TITLE
Add Mariner Dockerfile with GOLANG_FIPS=1

### DIFF
--- a/src/cbl-mariner/1.0.20211027/fips/Dockerfile
+++ b/src/cbl-mariner/1.0.20211027/fips/Dockerfile
@@ -1,0 +1,4 @@
+FROM golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-1.0.20211027
+
+# Enable Go FIPS mode, even if the container host isn't in an enabled mode.
+ENV GOLANG_FIPS=1


### PR DESCRIPTION
For CI, it makes sense to produce another image that has GOLANG_FIPS=1 to test under that configuration.

* See https://github.com/microsoft/go/pull/297.

The image build works like this:

1. Build `src/cbl-mariner/1.0.20211027/amd64/Dockerfile`. Tag it as:
   * `golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-1.0.20211027-20211201-0cccc22`
   * `golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-1.0.20211027` (don't push this one)
2. Build `src/cbl-mariner/1.0.20211027/fips/Dockerfile`. Tag it as:
   * `golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-1.0.20211027-fips-20211206-e78b6d3`

The infra will be generating the `20211201-0cccc22` part. The tag without `20211201-0cccc22` allows us to build the FIPS Dockerfile without modifying it to include `20211201-0cccc22` in the `BASE` image reference. In the `manifest.json`, it looks like this: https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/24c5ab1f1ea07aff18581a627346c3bcbbfc885b/manifest.json#L759-L762.

I've pushed this to `golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-1.0.20211027-fips-20211206-e78b6d3`