### PR TITLE
Add openssl docker file

### DIFF
--- a/src/cbl-mariner/1.0.20211027/amd64/openssl/Dockerfile
+++ b/src/cbl-mariner/1.0.20211027/amd64/openssl/Dockerfile
@@ -1,0 +1,25 @@
+FROM cblmariner.azurecr.io/base/core:1.0.20211027
+
+# Install build tools.
+RUN tdnf install -y \
+        ca-certificates-microsoft \
+        build-essential \
+    && tdnf clean all
+
+# Available OpenSSL versions at https://github.com/openssl/openssl/tags.
+ARG OPENSSL_VER="1.0.2u"
+
+# Download and decompress OpenSSL tarball.
+RUN [[ ${OPENSSL_VER} = 1.* ]] && openssl_name="OpenSSL_${OPENSSL_VER//./_}" || openssl_name="openssl-${OPENSSL_VER}" \
+    && wget https://github.com/openssl/openssl/archive/refs/tags/${openssl_name}.tar.gz -O - | tar -xz -C /usr/local/src \
+    && mv /usr/local/src/openssl-${openssl_name} /usr/local/src/openssl
+
+# Build OpenSSL.
+# Instructions taken from https://wiki.openssl.org/index.php/Compilation_and_Installation.
+RUN cd /usr/local/src/openssl \
+    && ./config shared \
+    && make build_libs
+
+# Copy OpenSSL shared libraries and include files into its finall location.
+RUN cp -r /usr/local/src/openssl/include/openssl /usr/include \
+    && cp -H /usr/local/src/openssl/libcrypto.so /usr/lib/libcrypto.so.${OPENSSL_VER}

--- a/src/cbl-mariner/openssl/Dockerfile
+++ b/src/cbl-mariner/openssl/Dockerfile
@@ -23,5 +23,5 @@ RUN cd /usr/local/src/openssl \
     && make build_libs
 
 # Copy OpenSSL shared libraries and include files into its finall location.
-RUN cp -r /usr/local/src/openssl/include/openssl /usr/include \
+RUN cp -r -L /usr/local/src/openssl/include/openssl /usr/include \
     && cp -H /usr/local/src/openssl/libcrypto.so /usr/lib/libcrypto.so.${OPENSSL_VER}

--- a/src/cbl-mariner/openssl/Dockerfile
+++ b/src/cbl-mariner/openssl/Dockerfile
@@ -1,4 +1,6 @@
-FROM cblmariner.azurecr.io/base/core:1.0.20211027
+ARG MARINER_VER="1.0.20211027"
+
+FROM cblmariner.azurecr.io/base/core:${MARINER_VER}
 
 # Install build tools.
 RUN tdnf install -y \


### PR DESCRIPTION
This PR contains a new Dockerfile which builds from source the desired OpenSSL version within a CBL Mariner image.

This image can be useful in a multistage docker file, where one of the stages copies the OpenSSL shared library and include directory to another stage.

The provided shared libraries do not support FIPS mode, as it requires additional build steps that are not implemented in this PR.