### PR TITLE
Remove specific date and arch from Mariner Dockerfiles; build an arm64 CI image

### DIFF
--- a/src/cbl-mariner/1.0/default/Dockerfile
+++ b/src/cbl-mariner/1.0/default/Dockerfile
@@ -1,4 +1,4 @@
-FROM cblmariner.azurecr.io/base/core:1.0.20211027
+FROM cblmariner.azurecr.io/base/core:1.0
 
 # Install dependencies needed to build, test, and longtest Go.
 RUN tdnf install -y \

--- a/src/cbl-mariner/1.0/fips/Dockerfile
+++ b/src/cbl-mariner/1.0/fips/Dockerfile
@@ -1,4 +1,4 @@
-FROM golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-1.0.20211027
+FROM golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-1.0
 
 # Enable Go FIPS mode, even if the container host isn't in an enabled mode.
 ENV GOLANG_FIPS=1


### PR DESCRIPTION
* Remove `.20211027` from `cblmariner.azurecr.io/base/core:1.0.20211027` because that tag is no longer available. `1.0` pulls the latest 1.0 version of CBL-Mariner, which is what we want anyway.
* Instead of an `amd64` specific directory for our main Mariner Dockerfile, call it `default`. We can build amd64 and arm64 tags just fine from the one Dockerfile.
  * If there were something arch-specific in there (like there is for Ubuntu, which downloads CMake for x86_64), there would be more to do here. The official [Go Docker Dockerfiles have a big `case`](https://github.com/docker-library/golang/blob/67757c0feeb9867a54801ca378dcfc55b9db7e70/1.17/buster/Dockerfile#L29-L58) to handle this. .NET Docker opts for [arch-specific Dockerfiles](https://github.com/dotnet/dotnet-docker/blob/main/src/sdk/6.0/focal/arm64v8/Dockerfile).

I manually built this locally under QEMU to use it with microsoft/go arm64 CI, and published it as `golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-arm64-1.0-20220314-a003148`. Since we don't have any CI yet for go-infra-images, this PR doesn't actually block the work in microsoft/go.