### PR TITLE
Add missing TSA file

### DIFF
--- a/.config/tsa/tsaoptions.json
+++ b/.config/tsa/tsaoptions.json
@@ -1,0 +1,14 @@
+{
+  "codebaseName": "Go",
+  "notificationAliases": [
+    "golangdev@microsoft.com"
+  ],
+  "codebaseAdmins": [
+    "redmond\\golangdev"
+  ],
+  "instanceUrl": "https://devdiv.visualstudio.com/",
+  "projectName": "DEVDIV",
+  "areaPath": "DevDiv\\NET Compilers\\GoLang",
+  "iterationPath": "DevDiv",
+  "allTools": true
+}

--- a/eng/pipeline/rolling-internal-validation-pipeline.yml
+++ b/eng/pipeline/rolling-internal-validation-pipeline.yml
@@ -56,8 +56,6 @@ extends:
       codeql:
         enabledOnNonDefaultBranches: ${{ parameters.enableCodeQL }}
         language: go,powershell
-      suppression:
-        suppressionFile: $(Build.SourcesDirectory)/eng/compliance/.gdnsuppress
       tsa:
         enabled: ${{ not(parameters.disableTSA) }}
         configFile: $(Build.SourcesDirectory)/.config/tsa/tsaoptions.json

--- a/eng/pipeline/rolling-internal-validation-pipeline.yml
+++ b/eng/pipeline/rolling-internal-validation-pipeline.yml
@@ -60,7 +60,7 @@ extends:
         suppressionFile: $(Build.SourcesDirectory)/eng/compliance/.gdnsuppress
       tsa:
         enabled: ${{ not(parameters.disableTSA) }}
-        configFile: $(Build.SourcesDirectory)/eng/compliance/tsaoptions.json
+        configFile: $(Build.SourcesDirectory)/.config/tsa/tsaoptions.json
 
     stages:
       - stage: Analyze


### PR DESCRIPTION
The [
microsoft-go-infra-images-rolling-internal-validation](https://dev.azure.com/dnceng/internal/_build?definitionId=1358&_a=summary) pipeline is currently reporting a warning saying that the TSA file does not exist. #11 added a reference to it without adding the file. Do it now.

While here, remove the GDN suppression file, as it is neither checked in the repo and not needed for now.