### PR TITLE
Update and set up pipelines to target MAR publish; build from in-support base images

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,12 @@ To build all Docker tags in this repository, run `pwsh build.ps1` in the root of
 
 ## Updating manifest.json
 
-After modifying the Dockerfiles, run `go run ./cmd/geninfraimagesmanifest` in the root of the repository. This regenerates the `manifest.json` file according to directory naming conventions. The `manifest.json` file is used by the `build.ps1` build process and CI builds.
+After adding or removing any Dockerfile, run `go run ./cmd/geninfraimagesmanifest` in the root of the repository.
+This regenerates the `manifest.json` file according to directory naming conventions.
+The `manifest.json` file is used by the `build.ps1` build process and CI builds.
+
+As long as your Dockerfile matches the conventions we expect in this repository, the command will succeed.
+If it doesn't succeed, you may need to move the Dockerfile or edit the command.
 
 ## Contributing
 

--- a/build.ps1
+++ b/build.ps1
@@ -1,18 +1,26 @@
 #!/usr/bin/env pwsh
-# From https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/c54d34b99929259dc16252692e7bbd0da781559c/build.ps1
-[cmdletbinding()]
 param(
-    [string]$DockerfilePath = "*",
-    [string]$ImageBuilderCustomArgs
+    # Name of OS to filter by
+    [string]$OS,
+
+    # Type of architecture to filter by
+    [string]$Architecture,
+
+    # Additional custom path filters
+    [string[]]$Paths,
+
+    # Additional args to pass to ImageBuilder
+    [string]$OptionalImageBuilderArgs
 )
 
-Set-StrictMode -Version Latest
-$ErrorActionPreference = 'Stop'
-pushd $PSScriptRoot
-$ImageBuilderCustomArgs = "$ImageBuilderCustomArgs --var UniqueId=$(Get-Date -Format yyyyMMddHHmmss)"
-try {
-    ./eng/common/Invoke-ImageBuilder.ps1 "build --path '$DockerfilePath' $ImageBuilderCustomArgs"
-}
-finally {
-    popd
-}
+# This script is copied from .NET Docker and modified to suit our usage. See the original script
+# (https://github.com/dotnet/dotnet-docker/blob/main/build-and-test.ps1) when adding more
+# functionality here. Follow the .NET Docker methodology when possible for consistency and
+# compatibility with changes to the core .NET Docker shared infrastructure.
+
+# Build the product images.
+& $PSScriptRoot/common/build.ps1 `
+    -OS $OS `
+    -Architecture $Architecture `
+    -Paths $Paths `
+    -OptionalImageBuilderArgs $OptionalImageBuilderArgs

--- a/cmd/geninfraimagesmanifest/main.go
+++ b/cmd/geninfraimagesmanifest/main.go
@@ -68,7 +68,7 @@ func run() error {
 				{
 					Architecture: arch,
 					Variant:      archVariant,
-					Dockerfile:   filepath.Dir(path),
+					Dockerfile:   filepath.ToSlash(filepath.Dir(path)),
 					OS:           os,
 					OSVersion:    version,
 					Tags: map[string]dockermanifest.Tag{
@@ -90,13 +90,13 @@ func run() error {
 
 	m := &dockermanifest.Manifest{
 		Readme:    map[string]string{"path": "README.md"},
-		Registry:  "golangpublicimages.azurecr.io",
+		Registry:  "mcr.microsoft.com",
 		Variables: make(map[string]interface{}),
 		Includes:  make([]string, 0),
 		Repos: []*dockermanifest.Repo{
 			{
-				ID:     "prereqs",
-				Name:   "go-infra-images/prereqs",
+				ID:     "infra-images",
+				Name:   "microsoft-go/infra-images",
 				Images: images,
 			},
 		},

--- a/eng/common/templates/1es-official.yml
+++ b/eng/common/templates/1es-official.yml
@@ -17,8 +17,13 @@ parameters:
 - name: stages
   type: stageList
   default: []
-  # 1ES Pipeline Template parameters
 - name: pool
+  type: object
+  default:
+    name: NetCore1ESPool-Internal
+    image: 1es-ubuntu-2204
+    os: linux
+- name: sourceAnalysisPool
   type: object
   default:
     name: NetCore1ESPool-Internal
@@ -45,4 +50,5 @@ extends:
         exclude:
         - repository: InternalVersionsRepo
         - repository: PublicVersionsRepo
+      sourceAnalysisPool: ${{ parameters.sourceAnalysisPool }}
     stages: ${{ parameters.stages }}

--- a/eng/common/templates/1es-unofficial.yml
+++ b/eng/common/templates/1es-unofficial.yml
@@ -44,6 +44,8 @@ extends:
         ignoreDirectories: $(Build.SourcesDirectory)/versions
         whatIf: true
         showAlertLink: true
+      sbom:
+        enabled: true
       sourceRepositoriesToScan:
         exclude:
         - repository: InternalVersionsRepo

--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -88,16 +88,21 @@ jobs:
     condition: eq(variables.imageBuilderBuildArgs, '')
     displayName: Initialize Image Builder Build Args
   - powershell: |
+      New-Item -Path $(imageInfoHostDir) -ItemType Directory -Force
+
       # Reference the existing imageBuilderBuildArgs variable as an environment variable rather than injecting it directly
       # with the $(imageBuilderBuildArgs) syntax. This is to avoid issues where the string may contain single quotes $ chars
       # which really mess up assigning to a variable. It would require assigning the string with single quotes but also needing
       # to escape the single quotes that are in the string which would need to be done outside the context of PowerShell. Since
       # all we need is for that value to be in a PowerShell variable, we can get that by the fact that AzDO automatically creates
       # the environment variable for us.
-      New-Item -Path $(imageInfoHostDir) -ItemType Directory -Force
       $imageBuilderBuildArgs = "$env:IMAGEBUILDERBUILDARGS $(imageBuilder.queueArgs) --image-info-output-path $(imageInfoContainerDir)/$(legName)-image-info.json"
       if ($env:SYSTEM_TEAMPROJECT -eq "${{ parameters.internalProjectName }}" -and $env:BUILD_REASON -ne "PullRequest") {
-        $imageBuilderBuildArgs = "$imageBuilderBuildArgs --registry-override $(acr.server) --repo-prefix $(stagingRepoPrefix) --source-repo-prefix $(mirrorRepoPrefix) --push --registry-creds ""$(acr.server)=$(acr.userName);$(acr.password)"""
+        $imageBuilderBuildArgs = "$imageBuilderBuildArgs --registry-override $(acr-staging.server) --repo-prefix $(stagingRepoPrefix) --source-repo-prefix $(mirrorRepoPrefix) --push"
+      }
+
+      if ($env:SYSTEM_TEAMPROJECT -eq "${{ parameters.publicProjectName }}" -and ${env:PUBLIC-MIRROR_SERVER} -ne "") {
+        $imageBuilderBuildArgs = "$imageBuilderBuildArgs --base-override-regex '^(?!mcr\.microsoft\.com)' --base-override-sub '$(public-mirror.server)/'"
       }
 
       # If the pipeline isn't configured to disable the cache and a build variable hasn't been set to disable the cache
@@ -105,27 +110,30 @@ jobs:
         $imageBuilderBuildArgs = "$imageBuilderBuildArgs --image-info-source-path $(versionsBasePath)$(imageInfoVersionsPath)"
       }
 
+      echo "imageBuilderBuildArgs: $imageBuilderBuildArgs"
       echo "##vso[task.setvariable variable=imageBuilderBuildArgs]$imageBuilderBuildArgs"
     displayName: Set Image Builder Build Args
-  - powershell: >
-      $(runImageBuilderCmd) build
-      --manifest $(manifest)
-      $(imageBuilderPaths)
-      $(osVersions)
-      --os-type $(osType)
-      --architecture $(architecture)
-      --retry
-      --source-repo $(publicGitRepoUri)
-      --digests-out-var 'builtImages'
-      --acr-subscription '$(acr.subscription)'
-      --acr-resource-group '$(acr.resourceGroup)'
-      --acr-client-id '$(acr.servicePrincipalName)'
-      --acr-password '$(acr.servicePrincipalPassword)'
-      --acr-tenant '$(acr.servicePrincipalTenant)'
-      $(manifestVariables)
-      $(imageBuilderBuildArgs)
-    name: BuildImages
-    displayName: Build Images
+  - template: /eng/common/templates/steps/run-imagebuilder.yml@self
+    parameters:
+      name: BuildImages
+      displayName: Build Images
+      serviceConnection: $(build.serviceConnectionName)
+      internalProjectName: ${{ parameters.internalProjectName }}
+      dockerClientOS: ${{ parameters.dockerClientOS }}
+      args: >
+        build
+        --manifest $(manifest)
+        $(imageBuilderPaths)
+        $(osVersions)
+        --os-type $(osType)
+        --architecture $(architecture)
+        --retry
+        --source-repo $(publicGitRepoUri)
+        --digests-out-var 'builtImages'
+        --acr-subscription '$(acr-staging.subscription)'
+        --acr-resource-group '$(acr-staging.resourceGroup)'
+        $(manifestVariables)
+        $(imageBuilderBuildArgs)
   - template: /eng/common/templates/steps/publish-artifact.yml@self
     parameters:
       path: $(imageInfoHostDir)
@@ -134,13 +142,8 @@ jobs:
       internalProjectName: ${{ parameters.internalProjectName }}
       publicProjectName: ${{ parameters.publicProjectName }}
   - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
-      # Define the task here to load it into the agent so that we can invoke the tool manually
-      # TODO: Revert the build-specific pinned version when https://github.com/dotnet/docker-tools/issues/1152 is fixed
-    - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0.197.56
-      inputs:
-        BuildDropPath: $(Build.ArtifactStagingDirectory)
-      displayName: Load Manifest Generator
-      condition: and(succeeded(), ne(variables['BuildImages.builtImages'], ''))
+    # The following task depends on the SBOM Manifest Generator task installed on the agent.
+    # This task is auto-injected by 1ES Pipeline Templates so we don't need to install it ourselves.
     - powershell: |
         $images = "$(BuildImages.builtImages)"
         if (-not $images) { return 0 }
@@ -175,7 +178,7 @@ jobs:
         # Manifest tool docs: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/custom-sbom-generation-workflows
         $images -Split ',' | ForEach-Object {
           echo "Generating SBOM for $_";
-          $formattedImageName = $_.Replace('$(acr.server)/$(stagingRepoPrefix)', "").Replace('/', '_').Replace(':', '_');
+          $formattedImageName = $_.Replace('$(acr-staging.server)/$(stagingRepoPrefix)', "").Replace('/', '_').Replace(':', '_');
           $sbomChildDir = "$(sbomDirectory)/$formattedImageName";
           New-Item -Type Directory -Path $sbomChildDir > $null;
           & $dotnetPath "$manifestToolDllPath" `

--- a/eng/common/templates/jobs/copy-base-images-staging.yml
+++ b/eng/common/templates/jobs/copy-base-images-staging.yml
@@ -1,0 +1,30 @@
+parameters:
+- name: name
+  type: string
+  default: null
+- name: pool
+  type: object
+  default: {}
+- name: customInitSteps
+  type: stepList
+  default: []
+- name: additionalOptions
+  type: string
+  default: ''
+- name: continueOnError
+  type: string
+  default: false
+
+jobs:
+- template: /eng/common/templates/jobs/copy-base-images.yml@self
+  parameters:
+    name: ${{ parameters.name }}
+    pool: ${{ parameters.pool }}
+    customInitSteps: ${{ parameters.customInitSteps }}
+    additionalOptions: ${{ parameters.additionalOptions }}
+    acr:
+      server: $(acr-staging.server)
+      serviceConnection: $(internal-mirror.serviceConnectionName)
+      subscription: $(acr-staging.subscription)
+      resourceGroup: $(acr-staging.resourceGroup)
+    repoPrefix: $(mirrorRepoPrefix)

--- a/eng/common/templates/jobs/copy-base-images.yml
+++ b/eng/common/templates/jobs/copy-base-images.yml
@@ -1,9 +1,28 @@
 parameters:
-  name: null
-  pool: {}
-  additionalOptions: null
-  publicProjectName: null
-  customInitSteps: []
+- name: name
+  type: string
+  default: null
+- name: pool
+  type: object
+  default: {}
+- name: acr
+  type: object
+  default: null
+- name: repoPrefix
+  type: string
+  default: null
+- name: customInitSteps
+  type: stepList
+  default: []
+- name: additionalOptions
+  type: string
+  default: ''
+- name: continueOnError
+  type: string
+  default: false
+- name: forceDryRun
+  type: boolean
+  default: false
 
 jobs:
 - job: ${{ parameters.name }}
@@ -13,6 +32,8 @@ jobs:
   - ${{ parameters.customInitSteps }}
   - template: /eng/common/templates/steps/copy-base-images.yml@self
     parameters:
+      acr: ${{ parameters.acr }} 
+      repoPrefix: ${{ parameters.repoPrefix }}
       additionalOptions: ${{ parameters.additionalOptions }}
-      publicProjectName: ${{ parameters.publicProjectName }}
-      continueOnError: true
+      continueOnError: ${{ parameters.continueOnError }}
+      forceDryRun: ${{ parameters.forceDryRun }}

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -47,50 +47,45 @@ jobs:
     parameters:
       publicSourceBranch: $(publicSourceBranch)
   - template: /eng/common/templates/steps/set-dry-run.yml@self
-  - powershell: |
-      New-Item -ItemType Directory -Path $(sourceBuildIdOutputDir)
-      Set-Content -Path $(sourceBuildIdOutputDir)/source-build-id.txt -Value $(sourceBuildId)
-    displayName: Write Source Build ID to File
-  - template: /eng/common/templates/steps/publish-artifact.yml@self
-    parameters:
-      path: $(sourceBuildIdOutputDir)
-      artifactName: source-build-id
-      displayName: Publish Source Build ID Artifact
-      internalProjectName: ${{ parameters.internalProjectName }}
-      publicProjectName: ${{ parameters.publicProjectName }}
   - script: echo "##vso[task.setvariable variable=imageQueueTime]$(date --rfc-2822)"
     displayName: Set Publish Variables
   - script: >
       $(runImageBuilderCmd) trimUnchangedPlatforms
       '$(imageInfoContainerDir)/image-info.json'
     displayName: Trim Unchanged Images
-  - script: >
-      $(runImageBuilderCmd) copyAcrImages
-      '$(acr.servicePrincipalName)'
-      '$(acr.servicePrincipalPassword)'
-      '$(acr.servicePrincipalTenant)'
-      '$(acr.subscription)'
-      '$(acr.resourceGroup)'
-      '$(stagingRepoPrefix)'
-      --os-type '*'
-      --architecture '*'
-      --repo-prefix '$(publishRepoPrefix)'
-      --image-info '$(imageInfoContainerDir)/image-info.json'
-      $(dryRunArg)
-      $(imageBuilder.pathArgs)
-      $(imageBuilder.commonCmdArgs)
-    displayName: Copy Images
-  - script: >
-      $(runImageBuilderCmd) publishManifest
-      '$(imageInfoContainerDir)/image-info.json'
-      --repo-prefix '$(publishRepoPrefix)'
-      --registry-creds '$(acr.server)=$(acr.userName);$(acr.password)'
-      --os-type '*'
-      --architecture '*'
-      $(dryRunArg)
-      $(imageBuilder.pathArgs)
-      $(imageBuilder.commonCmdArgs)
-    displayName: Publish Manifest
+  - template: /eng/common/templates/steps/run-imagebuilder.yml@self
+    parameters:
+      displayName: Copy Images
+      serviceConnection: $(publish.serviceConnectionName)
+      internalProjectName: ${{ parameters.internalProjectName }}
+      args: >
+        copyAcrImages
+        '$(acr.subscription)'
+        '$(acr.resourceGroup)'
+        '$(stagingRepoPrefix)'
+        '$(acr-staging.server)'
+        --os-type '*'
+        --architecture '*'
+        --repo-prefix '$(publishRepoPrefix)'
+        --image-info '$(imageInfoContainerDir)/image-info.json'
+        $(dryRunArg)
+        $(imageBuilder.pathArgs)
+        $(imageBuilder.commonCmdArgs)
+  - template: /eng/common/templates/steps/run-imagebuilder.yml@self
+    parameters:
+      displayName: Publish Manifest
+      serviceConnection: $(publish.serviceConnectionName)
+      internalProjectName: ${{ parameters.internalProjectName }}
+      dockerClientOS: ${{ parameters.dockerClientOS }}
+      args: >
+        publishManifest
+        '$(imageInfoContainerDir)/image-info.json'
+        --repo-prefix '$(publishRepoPrefix)'
+        --os-type '*'
+        --architecture '*'
+        $(dryRunArg)
+        $(imageBuilder.pathArgs)
+        $(imageBuilder.commonCmdArgs)
   - template: /eng/common/templates/steps/publish-artifact.yml@self
     parameters:
       path: $(imageInfoHostDir)
@@ -122,22 +117,23 @@ jobs:
       $(imageBuilder.commonCmdArgs)
     condition: and(succeeded(), eq(variables['publishImageInfo'], 'true'))
     displayName: Publish Image Info
-  - script: >
-      $(runImageBuilderCmd) ingestKustoImageInfo
-      '$(imageInfoContainerDir)/image-info.json'
-      '$(kusto.cluster)'
-      '$(kusto.database)'
-      '$(kusto.imageTable)'
-      '$(kusto.layerTable)'
-      '$(kusto.servicePrincipalName)'
-      '$(kusto.servicePrincipalPassword)'
-      '$(kusto.servicePrincipalTenant)'
-      --os-type '*'
-      --architecture '*'
-      $(dryRunArg)
-      $(imageBuilder.commonCmdArgs)
-    displayName: Ingest Kusto Image Info
-    condition: and(succeeded(), eq(variables['ingestKustoImageInfo'], 'true'))
+  - template: /eng/common/templates/steps/run-imagebuilder.yml@self
+    parameters:
+      displayName: Ingest Kusto Image Info
+      serviceConnection: $(kusto.serviceConnectionName)
+      internalProjectName: ${{ parameters.internalProjectName }}
+      condition: and(succeeded(), eq(variables['ingestKustoImageInfo'], 'true'))
+      args: >
+        ingestKustoImageInfo
+        '$(imageInfoContainerDir)/image-info.json'
+        '$(kusto.cluster)'
+        '$(kusto.database)'
+        '$(kusto.imageTable)'
+        '$(kusto.layerTable)'
+        --os-type '*'
+        --architecture '*'
+        $(dryRunArg)
+        $(imageBuilder.commonCmdArgs)
   - script: >
       $(runImageBuilderCmd) postPublishNotification
       '$(publishNotificationRepoName)'
@@ -151,14 +147,26 @@ jobs:
       '$(gitHubNotificationsRepoInfo.org)'
       '$(gitHubNotificationsRepoInfo.repo)'
       --repo-prefix '$(publishRepoPrefix)'
-      --task "Copy Images"
-      --task "Publish Manifest"
-      --task "Wait for Image Ingestion"
+      --task "Copy Images (Authenticated)"
+      --task "Publish Manifest (Authenticated)"
+      --task "Wait for Image Ingestion (Authenticated)"
       --task "Publish Readmes"
-      --task "Wait for MCR Doc Ingestion"
+      --task "Wait for MCR Doc Ingestion (Authenticated)"
       --task "Publish Image Info"
-      --task "Ingest Kusto Image Info"
+      --task "Ingest Kusto Image Info (Authenticated)"
       $(dryRunArg)
       $(imageBuilder.commonCmdArgs)
     displayName: Post Publish Notification
     condition: and(always(), eq(variables['publishNotificationsEnabled'], 'true'))
+  - powershell: |
+      New-Item -ItemType Directory -Path $(sourceBuildIdOutputDir)
+      Set-Content -Path $(sourceBuildIdOutputDir)/source-build-id.txt -Value $(sourceBuildId)
+    condition: succeeded()
+    displayName: Write Source Build ID to File
+  - template: /eng/common/templates/steps/publish-artifact.yml@self
+    parameters:
+      path: $(sourceBuildIdOutputDir)
+      artifactName: source-build-id
+      displayName: Publish Source Build ID Artifact
+      internalProjectName: ${{ parameters.internalProjectName }}
+      publicProjectName: ${{ parameters.publicProjectName }}

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -8,7 +8,7 @@ parameters:
   customTestInitSteps: []
   customPublishInitSteps: []
   customPublishVariables: []
-  
+
   linuxAmdBuildJobTimeout: 60
   linuxArmBuildJobTimeout: 60
   windowsAmdBuildJobTimeout: 60
@@ -64,13 +64,12 @@ stages:
             echo "##vso[task.setvariable variable=osVersions]"
             echo "##vso[task.setvariable variable=architecture]"
           displayName: Initialize Test Variables
-  - template: /eng/common/templates/jobs/copy-base-images.yml@self
+  - template: /eng/common/templates/jobs/copy-base-images-staging.yml@self
     parameters:
       name: CopyBaseImages
       pool: ${{ parameters.linuxAmd64Pool }}
       additionalOptions: "--manifest '$(manifest)' $(imageBuilder.pathArgs) $(manifestVariables)"
-      publicProjectName: ${{ parameters.publicProjectName }}
-      customInitSteps: ${{ parameters.customCopyBaseImagesInitSteps}}
+      customInitSteps: ${{ parameters.customCopyBaseImagesInitSteps }}
   - template: /eng/common/templates/jobs/generate-matrix.yml@self
     parameters:
       matrixType: ${{ parameters.buildMatrixType }}

--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -14,6 +14,7 @@ parameters:
   windowsAmdBuildJobTimeout: 60
   windowsAmdTestJobTimeout: 60
   linuxAmdBuildJobTimeout: 60
+  linuxArmBuildJobTimeout: 60
   linuxAmd64Pool: ""
   buildMatrixType: platformDependencyGraph
   testMatrixType: platformVersionedOs
@@ -51,6 +52,7 @@ stages:
     windowsAmdBuildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
     windowsAmdTestJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     linuxAmdBuildJobTimeout: ${{ parameters.linuxAmdBuildJobTimeout }}
+    linuxArmBuildJobTimeout: ${{ parameters.linuxArmBuildJobTimeout }}
     buildMatrixType: ${{ parameters.buildMatrixType }}
     testMatrixType: ${{ parameters.testMatrixType }}
 

--- a/eng/common/templates/steps/annotate-eol-digests.yml
+++ b/eng/common/templates/steps/annotate-eol-digests.yml
@@ -1,0 +1,23 @@
+parameters:
+  internalProjectName: null
+  force: false
+  dataFile: null
+steps:
+  - script: |
+      optionalArgs=""
+      if [ "${{ lower(parameters.force) }}" == "true" ]; then
+        optionalArgs="$optionalArgs --force"
+      fi
+      echo "##vso[task.setvariable variable=optionalArgs]$optionalArgs"
+    displayName: Set Optional Args
+  - template: /eng/common/templates/steps/run-imagebuilder.yml@self
+    parameters:
+      name: AnnotateEOLImages
+      displayName: Annotate EOL Images
+      serviceConnection: $(publish.serviceConnectionName)
+      internalProjectName: ${{ parameters.internalProjectName }}
+      args: >
+        annotateEolDigests
+        /repo/${{ parameters.dataFile }}
+        $(acr.server)
+        $(optionalArgs)

--- a/eng/common/templates/steps/clean-acr-images.yml
+++ b/eng/common/templates/steps/clean-acr-images.yml
@@ -1,19 +1,24 @@
 parameters:
   repo: null
+  subscription: null
+  resourceGroup: null
+  acr: null
   action: null
   age: null
   customArgs: ""
+  internalProjectName: null
 steps:
-  - script: >
-      $(runImageBuilderCmd) cleanAcrImages
-      ${{ parameters.repo }}
-      $(acr.servicePrincipalName)
-      $(app-dotnetdockerbuild-client-secret)
-      $(acr.servicePrincipalTenant)
-      $(acr.subscription)
-      $(acr.resourceGroup)
-      $(acr.server)
-      --action ${{ parameters.action }}
-      --age ${{ parameters.age }}
-      ${{ parameters.customArgs }}
-    displayName: Clean ACR Images - ${{ parameters.repo }}
+  - template: /eng/common/templates/steps/run-imagebuilder.yml@self
+    parameters:
+      displayName: Clean ACR Images - ${{ parameters.repo }}
+      serviceConnection: $(clean.serviceConnectionName)
+      internalProjectName: ${{ parameters.internalProjectName }}
+      args: >
+        cleanAcrImages
+        ${{ parameters.repo }}
+        ${{ parameters.subscription }}
+        ${{ parameters.resourceGroup }}
+        ${{ parameters.acr }}
+        --action ${{ parameters.action }}
+        --age ${{ parameters.age }}
+        ${{ parameters.customArgs }}

--- a/eng/common/templates/steps/copy-base-images.yml
+++ b/eng/common/templates/steps/copy-base-images.yml
@@ -1,26 +1,45 @@
 parameters:
-  additionalOptions: null
-  publicProjectName: null
-  continueOnError: false
+- name: acr
+  type: object
+  default:
+    server: ""
+    serviceConnection: ""
+    subscription: ""
+    resourceGroup: ""
+- name: repoPrefix
+  type: string
+  default: null
+- name: additionalOptions
+  type: string
+  default: ""
+- name: continueOnError
+  type: string
+  default: false
+- name: forceDryRun
+  type: boolean
+  default: false
 
 steps:
-- ${{ if or(eq(variables['System.TeamProject'], parameters.publicProjectName), eq(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: /eng/common/templates/steps/set-dry-run.yml@self
-- script: >
-    $(runImageBuilderCmd)
-    copyBaseImages
-    '$(acr.servicePrincipalName)'
-    '$(acr.servicePrincipalPassword)'
-    '$(acr.servicePrincipalTenant)'
-    '$(acr.subscription)'
-    '$(acr.resourceGroup)'
-    $(dockerHubRegistryCreds)
-    $(customCopyBaseImagesArgs)
-    --repo-prefix $(mirrorRepoPrefix)
-    --registry-override '$(acr.server)'
-    --os-type 'linux'
-    --architecture '*'
-    $DRYRUNARG
-    ${{ parameters.additionalOptions }}
-  displayName: Copy Base Images
-  continueOnError: ${{ parameters.continueOnError }}
+- ${{ if or(eq(parameters.forceDryRun, true), eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
+  - script: echo "##vso[task.setvariable variable=dryRunArg]--dry-run"
+- template: /eng/common/templates/steps/run-imagebuilder.yml@self
+  parameters:
+    displayName: Copy Base Images
+    serviceConnection: ${{ parameters.acr.serviceConnection }}
+    continueOnError: ${{ parameters.continueOnError }}
+    internalProjectName: 'internal'
+    # Use environment variable to reference $(dryRunArg). Since $(dryRunArg) might be undefined,
+    # PowerShell will treat the Azure Pipelines variable macro syntax as a command and throw an
+    # error
+    args: >
+      copyBaseImages
+      '${{ parameters.acr.subscription }}'
+      '${{ parameters.acr.resourceGroup }}'
+      $(dockerHubRegistryCreds)
+      $(customCopyBaseImagesArgs)
+      --repo-prefix '${{ parameters.repoPrefix }}'
+      --registry-override '${{ parameters.acr.server }}'
+      --os-type 'linux'
+      --architecture '*'
+      $env:DRYRUNARG
+      ${{ parameters.additionalOptions }}

--- a/eng/common/templates/steps/init-docker-linux.yml
+++ b/eng/common/templates/steps/init-docker-linux.yml
@@ -34,16 +34,45 @@ steps:
       -f $(engCommonPath)/Dockerfile.WithRepo .
     displayName: Build Image for Image Builder
     condition: and(succeeded(), ${{ parameters.condition }})
-  - script: >
-      echo "##vso[task.setvariable variable=runImageBuilderCmd]
-      docker run --rm
-      -v /var/run/docker.sock:/var/run/docker.sock
-      -v $(Build.ArtifactStagingDirectory):$(artifactsPath)
-      -w /repo
-      $(imageBuilderDockerRunExtraOptions)
-      $(imageNames.imageBuilder.withrepo)"
-    displayName: Define runImageBuilderCmd Variable
+  - task: PowerShell@2
+    displayName: Define ImageBuilder Command Variables
     condition: and(succeeded(), ${{ parameters.condition }})
+    inputs:
+      targetType: 'inline'
+      script: |
+        $tokenHostPath = '$(Agent.TempDirectory)'
+        $tokenHostFilePath = "${tokenHostPath}/token"
+        $tokenContainerPath = "/tmp"
+        $tokenContainerFilePath = "${tokenContainerPath}/token"
+
+        $dockerRunBaseCmd = @(
+          "docker run --rm"
+        )
+
+        $dockerRunArgs = @(
+          "-v /var/run/docker.sock:/var/run/docker.sock"
+          "-v $(Build.ArtifactStagingDirectory):$(artifactsPath)"
+          "-w /repo"
+          "$(imageBuilderDockerRunExtraOptions)"
+          "$(imageNames.imageBuilder.withrepo)"
+        )
+
+        $authedDockerRunArgs = @(
+          '-e AZURE_TENANT_ID=$env:tenantId'
+          '-e AZURE_CLIENT_ID=$env:servicePrincipalId'
+          "-e AZURE_FEDERATED_TOKEN_FILE=$tokenContainerFilePath"
+          "-v ${tokenHostPath}:${tokenContainerPath}"
+        )
+
+        $dockerRunCmd = $dockerRunBaseCmd + $dockerRunArgs
+        $authedDockerRunCmd = $dockerRunBaseCmd + $authedDockerRunArgs + $dockerRunArgs
+
+        $runImageBuilderCmd = $($dockerRunCmd -join ' ')
+        $runAuthedImageBuilderCmd = $($authedDockerRunCmd -join ' ')
+
+        Write-Host "##vso[task.setvariable variable=runImageBuilderCmd]$runImageBuilderCmd"
+        Write-Host "##vso[task.setvariable variable=runAuthedImageBuilderCmd]$runAuthedImageBuilderCmd"
+        Write-Host "##vso[task.setvariable variable=tokenHostFilePath]$tokenHostFilePath"
 
   ################################################################################
   # Setup Test Runner (Optional)

--- a/eng/common/templates/steps/init-docker-windows.yml
+++ b/eng/common/templates/steps/init-docker-windows.yml
@@ -37,8 +37,26 @@ steps:
     displayName: Cleanup Setup Container
     condition: and(always(), ${{ parameters.condition }})
     continueOnError: true
-  - powershell: >
-      echo "##vso[task.setvariable variable=runImageBuilderCmd]
-      $(Build.BinariesDirectory)\.Microsoft.DotNet.ImageBuilder\Microsoft.DotNet.ImageBuilder.exe"
-    displayName: Define runImageBuilderCmd Variable
+  - task: PowerShell@2
+    displayName: Define runImageBuilderCmd Variables
     condition: and(succeeded(), ${{ parameters.condition }})
+    inputs:
+      targetType: 'inline'
+      script: |
+        $tokenHostPath = '$(Agent.TempDirectory)'
+        $tokenHostFilePath = "$tokenHostPath\token"
+
+        $runImageBuilderCmd = "$(Build.BinariesDirectory)\.Microsoft.DotNet.ImageBuilder\Microsoft.DotNet.ImageBuilder.exe"
+
+        $authedImageBuilderCmds = @(
+          '$env:AZURE_TENANT_ID = $env:tenantId'
+          '$env:AZURE_CLIENT_ID = $env:servicePrincipalId'
+          '$env:AZURE_FEDERATED_TOKEN_FILE' + " = $tokenHostFilePath"
+          $runImageBuilderCmd
+        )
+
+        $runAuthedImageBuilderCmd = $($authedImageBuilderCmds -join "; ")
+
+        Write-Host "##vso[task.setvariable variable=runImageBuilderCmd]$runImageBuilderCmd"
+        Write-Host "##vso[task.setvariable variable=runAuthedImageBuilderCmd]$runAuthedImageBuilderCmd"
+        Write-Host "##vso[task.setvariable variable=tokenHostFilePath]$tokenHostFilePath"

--- a/eng/common/templates/steps/run-imagebuilder.yml
+++ b/eng/common/templates/steps/run-imagebuilder.yml
@@ -1,0 +1,52 @@
+parameters:
+- name: name
+  type: string
+  default: ""
+- name: displayName
+  type: string
+  default: "Run ImageBuilder"
+- name: serviceConnection
+  type: string
+  default: ""
+- name: internalProjectName
+  type: string
+  default: null
+- name: args
+  type: string
+  default: null
+- name: condition
+  type: string
+  default: succeeded()
+- name: continueOnError
+  type: boolean
+  default: false
+- name: dockerClientOS
+  type: string
+  default: "linux"
+
+steps:
+- ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest'), ne(parameters.serviceConnection, '')) }}:
+  - template: /eng/common/templates/steps/run-pwsh-with-auth.yml@self
+    parameters:
+      ${{ if ne(parameters.name, '') }}:
+        name: ${{ parameters.name }}
+      displayName: ${{ parameters.displayName }}
+      serviceConnection: ${{ parameters.serviceConnection }}
+      continueOnError: ${{ parameters.continueOnError }}
+      dockerClientOS: ${{ parameters.dockerClientOS }}
+      condition: ${{ parameters.condition }}
+      command: >
+        $env:idToken | Out-File -FilePath $(tokenHostFilePath);
+        $(runAuthedImageBuilderCmd) ${{ parameters.args }};
+        Remove-Item -Path $(tokenHostFilePath) -Force
+- ${{ else }}:
+  - task: PowerShell@2
+    ${{ if ne(parameters.name, '') }}:
+      name: ${{ parameters.name }}
+    displayName: ${{ parameters.displayName }}
+    continueOnError: ${{ parameters.continueOnError }}
+    condition: ${{ parameters.condition }}
+    inputs:
+      targetType: 'inline'
+      script: >
+        $(runImageBuilderCmd) ${{ parameters.args }}

--- a/eng/common/templates/steps/run-pwsh-with-auth.yml
+++ b/eng/common/templates/steps/run-pwsh-with-auth.yml
@@ -1,0 +1,39 @@
+parameters:
+- name: name
+  type: string
+  default: ""
+- name: displayName
+  type: string
+  default: "Run PowerShell"
+- name: serviceConnection
+  type: string
+  default: ""
+- name: command
+  type: string
+  default: null
+- name: continueOnError
+  type: boolean
+  default: false
+- name: dockerClientOS
+  type: string
+  default: "linux"
+- name: condition
+  type: string
+  default: true
+
+steps:
+- task: AzureCLI@2
+  ${{ if ne(parameters.name, '') }}:
+    name: ${{ parameters.name }}
+  displayName: ${{ parameters.displayName }} (Authenticated)
+  continueOnError: ${{ parameters.continueOnError }}
+  condition: and(succeeded(), ${{ parameters.condition }})
+  inputs:
+    azureSubscription: ${{ parameters.serviceConnection }}
+    addSpnToEnvironment: true
+    ${{ if eq(parameters.dockerClientOS, 'windows') }}:
+      scriptType: 'ps'
+    ${{ else }}:
+      scriptType: 'pscore'
+    scriptLocation: 'inlineScript'
+    inlineScript: ${{ parameters.command }};

--- a/eng/common/templates/steps/set-dry-run.yml
+++ b/eng/common/templates/steps/set-dry-run.yml
@@ -5,7 +5,7 @@ steps:
     if (-not "$(officialRepoPrefixes)".Split(',').Contains("$(publishRepoPrefix)") `
         -or "$(System.TeamProject)" -eq "$(publicProjectName)")
     {
-      $dryRunArg=" --dry-run"
+      $dryRunArg="--dry-run"
     }
     echo "##vso[task.setvariable variable=dryRunArg]$dryRunArg"
   displayName: Set dry-run arg for non-prod

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -22,7 +22,7 @@ steps:
       optionalTestArgs="$optionalTestArgs -TestCategories pre-build"
     else
       if [ "${{ variables['System.TeamProject'] }}" == "${{ parameters.internalProjectName }}" ] && [ "${{ variables['Build.Reason'] }}" != "PullRequest" ]; then
-        optionalTestArgs="$optionalTestArgs -PullImages -Registry $(acr.server) -RepoPrefix $(stagingRepoPrefix) -ImageInfoPath $(artifactsPath)/image-info.json"
+        optionalTestArgs="$optionalTestArgs -PullImages -Registry $(acr-staging.server) -RepoPrefix $(stagingRepoPrefix) -ImageInfoPath $(artifactsPath)/image-info.json"
       fi
       if [ "$REPOTESTARGS" != "" ]; then
         optionalTestArgs="$optionalTestArgs $REPOTESTARGS"
@@ -42,12 +42,16 @@ steps:
   displayName: Start Test Runner Container
   condition: and(succeeded(), ${{ parameters.condition }})
 - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
-  - script: >
-      docker exec $(testRunner.container) pwsh
-      -File $(engCommonRelativePath)/Invoke-WithRetry.ps1
-      "docker login -u $(acr.userName) -p $(acr.password) $(acr.server)"
-    displayName: Docker login
-    condition: and(succeeded(), ${{ parameters.condition }})
+  - template: /eng/common/templates/steps/run-pwsh-with-auth.yml@self
+    parameters:
+      displayName: Docker login
+      serviceConnection: $(test.serviceConnectionName)
+      condition: and(succeeded(), ${{ parameters.condition }})
+      command: >
+        $azLoginArgs = '--service-principal --tenant $env:AZURE_TENANT_ID -u $env:AZURE_CLIENT_ID --federated-token $env:AZURE_FEDERATED_TOKEN';
+        docker exec -e AZURE_TENANT_ID=$env:tenantId -e AZURE_CLIENT_ID=$env:servicePrincipalId -e AZURE_FEDERATED_TOKEN=$env:idToken $(testRunner.container) pwsh
+        -File $(engCommonRelativePath)/Invoke-WithRetry.ps1
+        "az login $azLoginArgs; az acr login -n $(acr-staging.server)"
   - ${{ if eq(parameters.preBuildValidation, 'false') }}:
     - template: /eng/common/templates/steps/download-build-artifact.yml@self
       parameters:
@@ -69,7 +73,7 @@ steps:
   displayName: Test Images
   condition: and(succeeded(), ${{ parameters.condition }})
 - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
-  - script: docker exec $(testRunner.container) docker logout $(acr.server)
+  - script: docker exec $(testRunner.container) docker logout $(acr-staging.server)
     displayName: Docker logout
     condition: and(always(), ${{ parameters.condition }})
     continueOnError: true

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -10,15 +10,20 @@ steps:
       cleanupDocker: true
       setupImageBuilder: false
       condition: ${{ parameters.condition }}
-  - powershell: >
-      $(engCommonPath)/Invoke-WithRetry.ps1
-      "cmd /c 'docker login -u $(acr.userName) --password $(acr.password) $(acr.server) 2>&1'"
-    displayName: Docker login
-    condition: and(succeeded(), ${{ parameters.condition }})
+  - template: /eng/common/templates/steps/run-pwsh-with-auth.yml@self
+    parameters:
+      displayName: Docker login
+      serviceConnection: $(test.serviceConnectionName)
+      dockerClientOS: windows
+      condition: and(succeeded(), ${{ parameters.condition }})
+      command: >
+        az login --service-principal --tenant $env:tenantId -u $env:servicePrincipalId --federated-token $env:idToken;
+        $accessToken = $(az acr login -n $(acr-staging.server) --expose-token --query accessToken --output tsv);
+        docker login $(acr-staging.server) -u 00000000-0000-0000-0000-000000000000 -p $accessToken
 - ${{ parameters.customInitSteps }}
 - powershell: |
     if ("${{ variables['System.TeamProject'] }}" -eq "${{ parameters.internalProjectName }}" -and "${{ variables['Build.Reason'] }}" -ne "PullRequest") {
-      $optionalTestArgs="$optionalTestArgs -PullImages -Registry $env:ACR_SERVER -RepoPrefix $env:STAGINGREPOPREFIX -ImageInfoPath $(artifactsPath)/image-info.json"
+      $optionalTestArgs="$optionalTestArgs -PullImages -Registry ${env:ACR-STAGING_SERVER} -RepoPrefix $env:STAGINGREPOPREFIX -ImageInfoPath $(artifactsPath)/image-info.json"
     }
     if ($env:REPOTESTARGS) {
       $optionalTestArgs += " $env:REPOTESTARGS"
@@ -45,7 +50,7 @@ steps:
   displayName: Test Images
   condition: and(succeeded(), ${{ parameters.condition }})
 - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
-  - script: docker logout $(acr.server)
+  - script: docker logout $(acr-staging.server)
     displayName: Docker logout
     condition: and(always(), ${{ parameters.condition }})
     continueOnError: true

--- a/eng/common/templates/steps/validate-branch.yml
+++ b/eng/common/templates/steps/validate-branch.yml
@@ -4,11 +4,25 @@ parameters:
 steps:
 - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - powershell: |
-      if (-not "$(officialBranches)".Split(',').Contains("$(sourceBranch)") `
-          -and "$(officialBranches)".Split(',').Contains("$(publishRepoPrefix)") `
-          -and "$(overrideOfficialBranchValidation)" -ne "true")
+      if ("$(officialBranches)".Split(',').Contains("$(sourceBranch)") `
+          -and "$(officialRepoPrefixes)".Split(',').Contains("$(publishRepoPrefix)"))
       {
-        echo "##vso[task.logissue type=error]Official builds must be done from an official branch: $(officialBranches)"
-        exit 1
+        echo "Conditions met for official build, continuing..."
+        exit 0
       }
+
+      if (-not "$(officialRepoPrefixes)".Split(',').Contains("$(publishRepoPrefix)"))
+      {
+        echo "This build is a test build, continuing..."
+        exit 0
+      }
+
+      if ("$(overrideOfficialBranchValidation)" -eq "true")
+      {
+        echo "Variable overrideOfficialBranchValidation is set to true, continuing..."
+        exit 0
+      }
+
+      echo "##vso[task.logissue type=error]Official builds must be done from an official branch ($(officialBranches)) and repo prefix ($(officialRepoPrefixes))."
+      exit 1
     displayName: Validate Branch

--- a/eng/common/templates/steps/wait-for-mcr-doc-ingestion.yml
+++ b/eng/common/templates/steps/wait-for-mcr-doc-ingestion.yml
@@ -4,13 +4,14 @@ parameters:
   dryRunArg: ""
 
 steps:
-- script: >
-    $(runImageBuilderCmd) waitForMcrDocIngestion
-    '${{ parameters.commitDigest }}'
-    '$(mcrStatus.servicePrincipalName)'
-    '$(mcrStatus.servicePrincipalPassword)'
-    '$(mcrStatus.servicePrincipalTenant)'
-    --timeout '$(mcrDocIngestionTimeout)'
-    ${{ parameters.dryRunArg }}
-  displayName: Wait for MCR Doc Ingestion
-  condition: and(${{ parameters.condition }}, eq(variables['waitForIngestionEnabled'], 'true'))
+- template: /eng/common/templates/steps/run-imagebuilder.yml@self
+  parameters:
+    displayName: Wait for MCR Doc Ingestion
+    condition: and(${{ parameters.condition }}, eq(variables['waitForIngestionEnabled'], 'true'))
+    serviceConnection: $(marStatus.serviceConnectionName)
+    internalProjectName: 'internal'
+    args: >
+      waitForMcrDocIngestion
+      '${{ parameters.commitDigest }}'
+      --timeout '$(mcrDocIngestionTimeout)'
+      ${{ parameters.dryRunArg }}

--- a/eng/common/templates/steps/wait-for-mcr-image-ingestion.yml
+++ b/eng/common/templates/steps/wait-for-mcr-image-ingestion.yml
@@ -5,17 +5,18 @@ parameters:
   dryRunArg: ""
 
 steps:
-- script: >
-    $(runImageBuilderCmd) waitForMcrImageIngestion
-    '${{ parameters.imageInfoPath }}'
-    '$(mcrStatus.servicePrincipalName)'
-    '$(mcrStatus.servicePrincipalPassword)'
-    '$(mcrStatus.servicePrincipalTenant)'
-    --manifest '$(manifest)'
-    --repo-prefix '$(publishRepoPrefix)'
-    --min-queue-time '${{ parameters.minQueueTime }}'
-    --timeout '$(mcrImageIngestionTimeout)'
-    $(manifestVariables)
-    ${{ parameters.dryRunArg }}
-  displayName: Wait for Image Ingestion
-  condition: and(${{ parameters.condition }}, eq(variables['waitForIngestionEnabled'], 'true'))
+- template: /eng/common/templates/steps/run-imagebuilder.yml@self
+  parameters:
+    displayName: Wait for Image Ingestion
+    condition: and(${{ parameters.condition }}, eq(variables['waitForIngestionEnabled'], 'true'))
+    serviceConnection: $(marStatus.serviceConnectionName)
+    internalProjectName: 'internal'
+    args: >
+      waitForMcrImageIngestion
+      '${{ parameters.imageInfoPath }}'
+      --manifest '$(manifest)'
+      --repo-prefix '$(publishRepoPrefix)'
+      --min-queue-time '${{ parameters.minQueueTime }}'
+      --timeout '$(mcrImageIngestionTimeout)'
+      $(manifestVariables)
+      ${{ parameters.dryRunArg }}

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -55,3 +55,11 @@ variables:
   value: windows-2019
 - name: defaultWindows2022PoolImage
   value: windows-2022
+
+# Define these as placeholder values to allow string validation to succeed since we don't have the
+# variable group with the actual values in public builds. For internal builds, the variable group
+# will cause these values to be overridden with the real values.
+- name: acr.subscription
+  value: 00000000-0000-0000-0000-000000000000
+- name: acr-staging.subscription
+  value: 00000000-0000-0000-0000-000000000000

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2437925
+  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2499947
   imageNames.imageBuilder: $(imageNames.imageBuilderName)
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner2.0-docker-testrunner

--- a/eng/common/templates/variables/dotnet/build-test-publish.yml
+++ b/eng/common/templates/variables/dotnet/build-test-publish.yml
@@ -44,8 +44,3 @@ variables:
   value: $(dotnetDockerBot.userName)
 - name: gitHubVersionsRepoInfo.email
   value: $(dotnetDockerBot.email)
-
-- name: kusto.servicePrincipalPassword
-  value: $(app-DotnetDockerTelemetryIngestion-client-secret)
-- name: mcrStatus.servicePrincipalPassword
-  value: $(app-DotnetDockerMcrStatusApi-client-secret)

--- a/eng/common/templates/variables/dotnet/common.yml
+++ b/eng/common/templates/variables/dotnet/common.yml
@@ -6,11 +6,7 @@ variables:
   value: internal
 - name: dockerHubRegistryCreds
   value: --registry-creds 'docker.io=$(dotnetDockerHubBot.userName);$(BotAccount-dotnet-dockerhub-bot-PAT)'
-- name: acr.servicePrincipalPassword
-  value: $(app-dotnetdockerbuild-client-secret)
-- name: acr.password
-  value: $(BotAccount-dotnet-docker-acr-bot-password)
 
+- group: DotNet-Docker-Common
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-  - group: DotNet-Docker-Common
-  - group: DotNet-Docker-Secrets
+  - group: DotNet-Docker-Secrets-WIF

--- a/eng/pipeline/go-infra-images-pr-pipeline.yml
+++ b/eng/pipeline/go-infra-images-pr-pipeline.yml
@@ -10,9 +10,14 @@ variables:
 stages:
   - template: stages/build-test-publish-repo.yml
     parameters:
-      # "variables.x" template expression only gets the correct value in this pipeline file. In a
-      # stage template, it returns an empty string. So, evaluate it here and pass it through.
-      internalProjectName: ${{ variables.internalProjectName }}
-      publicProjectName: ${{ variables.publicProjectName }}
-      buildMatrixType: platformVersionedOs
+      extraParameters:
+        # "variables.x" template expression only gets the correct value in this pipeline file. In a
+        # stage template, it returns an empty string. So, evaluate it here and pass it through.
+        internalProjectName: ${{ variables.internalProjectName }}
+        publicProjectName: ${{ variables.publicProjectName }}
+        buildMatrixType: platformVersionedOs
   - template: stages/check-generation-repeatable.yml
+    parameters:
+      extraParameters:
+        internalProjectName: ${{ variables.internalProjectName }}
+        publicProjectName: ${{ variables.publicProjectName }}

--- a/eng/pipeline/go-infra-images-rolling-internal-pipeline.yml
+++ b/eng/pipeline/go-infra-images-rolling-internal-pipeline.yml
@@ -4,6 +4,13 @@ trigger:
     include:
       - main
 pr: none
+schedules:
+  - cron: '0 10 * * Tue,Thu'
+    displayName: Periodic build to refresh dependencies
+    branches:
+      include:
+        - microsoft/main
+    always: true
 
 variables:
   - template: variables/common.yml
@@ -18,14 +25,19 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
-    pool:
-      name: NetCore1ESPool-Internal
-      image: 1es-windows-2022
-      os: windows
+    sdl:
+      sourceAnalysisPool:
+        name: NetCore1ESPool-Internal
+        image: 1es-windows-2022
+        os: windows
+      tsa:
+        enabled: true
+        configFile: $(Build.SourcesDirectory)/.config/tsa/tsaoptions.json
     stages:
       - template: stages/build-test-publish-repo.yml
         parameters:
-          # "variables.x" template expression only gets the correct value in this pipeline file. In a
-          # stage template, it returns an empty string. So, evaluate it here and pass it through.
-          internalProjectName: ${{ variables.internalProjectName }}
-          publicProjectName: ${{ variables.publicProjectName }}
+          extraParameters:
+            # "variables.x" template expression only gets the correct value in this pipeline file. In a
+            # stage template, it returns an empty string. So, evaluate it here and pass it through.
+            internalProjectName: ${{ variables.internalProjectName }}
+            publicProjectName: ${{ variables.publicProjectName }}

--- a/eng/pipeline/rolling-internal-validation-pipeline.yml
+++ b/eng/pipeline/rolling-internal-validation-pipeline.yml
@@ -6,12 +6,6 @@
 
 trigger: none
 pr: none
-schedules:
-  - cron: '45 5 * * 2'
-    displayName: Weekly CodeQL
-    branches:
-      include:
-        - main
 
 # For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
 parameters:
@@ -39,6 +33,13 @@ variables:
       value: 0
 
 resources:
+  pipelines:
+    - pipeline: build
+      source: microsoft-go-infra-images-nightly
+      trigger:
+        branches:
+          include:
+            - main
   repositories:
     - repository: 1ESPipelineTemplates
       type: git
@@ -71,9 +72,11 @@ extends:
                 inputs:
                   version: 1.22.1
 
-              - script: go build ./...
+              - script: |
+                  go build ./...
                 displayName: go
 
               # Build no images, but exercise the PowerShell scripts.
-              - script: pwsh build.ps1 -DockerfilePath build_no_images
+              - script: |
+                  pwsh build.ps1 -Paths build_no_images
                 displayName: pwsh

--- a/eng/pipeline/stages/build-test-publish-repo.yml
+++ b/eng/pipeline/stages/build-test-publish-repo.yml
@@ -1,69 +1,73 @@
 # Create Go Docker image build and publish stages.
 parameters:
-  internalProjectName: null
-  publicProjectName: null
-  buildMatrixType: platformDependencyGraph
+  extraParameters: {}
 
 stages:
-  - template: ../../common/templates/stages/build-test-publish-repo.yml
+  - template: /eng/common/templates/stages/build-test-publish-repo.yml@self
     parameters:
       buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group build
       noCache: true
-      internalProjectName: ${{ parameters.internalProjectName }}
-      publicProjectName: ${{ parameters.publicProjectName }}
-      buildMatrixType: ${{ parameters.buildMatrixType }}
       # Template paths must be relative to the YAML job that executes them
       customBuildInitSteps:
-        - template: ../../../pipeline/steps/set-public-source-branch-var.yml
+        - template: /eng/pipeline/steps/set-imagebuilder-build-args-var.yml@self
+        - template: /eng/pipeline/steps/set-public-source-branch-var.yml@self
       customPublishInitSteps:
-        - template: ../../../pipeline/steps/set-public-source-branch-var.yml
+        - template: /eng/pipeline/steps/set-public-source-branch-var.yml@self
 
       # Linux AMD64
       linuxAmd64Pool:
-        ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
-          vmImage: $(defaultLinuxAmd64PoolImage)
-        ${{ elseif eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+        ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.publicProjectName) }}:
+          name: NetCore-Public
+          demands: ImageOverride -equals build.ubuntu.2204.amd64.open
+        ${{ elseif eq(variables['System.TeamProject'], parameters.extraParameters.internalProjectName) }}:
           name: NetCore1ESPool-Internal
           image: 1es-ubuntu-2204
           os: linux
-          
-      # Linux Arm64
+
+      # Linux ARM64
       linuxArm64Pool:
         os: linux
         hostArchitecture: Arm64
-        image: Mariner-2-Docker-ARM64
-        ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
-          name: DotNetCore-Docker-Public
-        ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+        ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.publicProjectName) }}:
+          name: Docker-Linux-Arm-Public
+        ${{ elseif eq(variables['System.TeamProject'], parameters.extraParameters.internalProjectName) }}:
           name: Docker-Linux-Arm-Internal
+          image: Mariner-2-Docker-ARM64
 
-      # Linux Arm32
+      # Linux ARM32
       linuxArm32Pool:
         os: linux
         hostArchitecture: Arm64
-        image: Mariner-2-Docker-ARM64
-        ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
-          name: DotNetCore-Docker-Public
-        ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+        ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.publicProjectName) }}:
+          name: Docker-Linux-Arm-Public
+        ${{ elseif eq(variables['System.TeamProject'], parameters.extraParameters.internalProjectName) }}:
           name: Docker-Linux-Arm-Internal
+          image: Mariner-2-Docker-ARM64
 
-      # Windows Server 2016
+      # Windows 2016
       windows2016Pool:
         os: windows
         name: Docker-2016-${{ variables['System.TeamProject'] }}
         ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
           image: Server2016-NESDockerBuilds-PT
 
-      # Windows Server 2019 (1809)
-      windows1809Pool:
-        os: windows
-        name: Docker-1809-${{ variables['System.TeamProject'] }}
-        ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
-          image: Server2019-1809-NESDockerBuilds-1ESPT
+      # Windows 2019 (1809)
+      ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.publicProjectName) }}:
+        windows1809Pool: Docker-1809-${{ variables['System.TeamProject'] }}
+      ${{ elseif eq(variables['System.TeamProject'], parameters.extraParameters.internalProjectName) }}:
+        windows1809Pool:
+          name: NetCore1ESPool-Internal
+          image: 1es-windows-2019
+          os: windows
 
-      # Windows Server 2022
-      windows2022Pool:
-        os: windows
-        name: Docker-2022-${{ variables['System.TeamProject'] }}
-        ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
-          image: Server2022-NESDockerBuilds-1ESPT
+      # Windows 2022
+      ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.publicProjectName) }}:
+        windows2022Pool: Docker-2022-${{ variables['System.TeamProject'] }}
+      ${{ elseif eq(variables['System.TeamProject'], parameters.extraParameters.internalProjectName) }}:
+        windows2022Pool:
+          name: NetCore1ESPool-Internal
+          image: 1es-windows-2022
+          os: windows
+
+      ${{ each pair in parameters.extraParameters }}:
+        ${{ pair.key }}: ${{ pair.value }}

--- a/eng/pipeline/stages/check-generation-repeatable.yml
+++ b/eng/pipeline/stages/check-generation-repeatable.yml
@@ -1,4 +1,8 @@
-# Check that manifest generation is repeatable.
+# Check that Dockerfile generation using "geninfraimagesmanifest" is repeatable. This makes sure the
+# manifest.json file is up to date and will build the correct images.
+parameters:
+  extraParameters: {}
+
 stages:
   - stage: Repeatability
     dependsOn: []
@@ -6,7 +10,12 @@ stages:
       - job: Test
         pool:
           # This is a utility job: use generic recent LTS.
-          vmImage: ubuntu-20.04
+          ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.publicProjectName) }}:
+            name: NetCore-Public
+            demands: ImageOverride -equals 1es-ubuntu-2004-open
+          ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.internalProjectName) }}:
+            name: NetCore1ESPool-Internal
+            demands: ImageOverride -equals 1es-ubuntu-2004
         workspace:
           clean: all
         steps:
@@ -14,7 +23,7 @@ stages:
 
           - task: GoTool@0
             inputs:
-              version: 1.19
+              version: 1.20
 
           - script: go run ./cmd/geninfraimagesmanifest
             displayName: Run geninfraimagesmanifest

--- a/eng/pipeline/steps/set-imagebuilder-build-args-var.yml
+++ b/eng/pipeline/steps/set-imagebuilder-build-args-var.yml
@@ -1,0 +1,14 @@
+# This is a copy of https://github.com/dotnet/dotnet-docker/blob/4e1b99dc7c62a3f4833a17b5a5ea298ae57b445b/eng/pipelines/steps/set-imagebuilder-build-args-var.yml
+# Skipping validation lets us avoid build breaks when Mariner changes how the platform is represented:
+# - https://github.com/microsoft/CBL-Mariner/issues/5008
+# - https://github.com/microsoft/CBL-Mariner/issues/4856
+steps:
+- powershell: |
+    $imageBuilderBuildArgs = $env:IMAGEBUILDERBUILDARGS
+    # Disable platform checks for CBL-Mariner on ARM64 due to https://github.com/dotnet/dotnet-docker/issues/3520
+    if ("$(osVersions)".Contains("cbl-mariner") -and "$(architecture)" -eq "arm64") {
+      $imageBuilderBuildArgs += " --skip-platform-check"
+    }
+
+    echo "##vso[task.setvariable variable=imageBuilderBuildArgs]$imageBuilderBuildArgs"
+  displayName: Set Custom ImageBuilder Build Args

--- a/eng/pipeline/variables/common.yml
+++ b/eng/pipeline/variables/common.yml
@@ -6,16 +6,22 @@ variables:
 - name: internalProjectName
   value: internal
 
-- name: commonVersionsImageInfoPath
-  value: build-info/docker
+# Credentials for pulling base images from Docker Hub.
+- name: dockerHubRegistryCreds
+  value: --registry-creds 'docker.io=$(dotnetDockerHubBot.userName);$(BotAccount-dotnet-dockerhub-bot-PAT)'
+
 - name: publicGitRepoUri
   value: https://github.com/microsoft/go
-- name: officialRepoPrefix
-  value: public/
+- name: officialRepoPrefixes
+  # Publish to "public/" or "private/internal/". Tags under these repo prefixes will be detected
+  # by MAR triggers and publish our images on the associated registry.
+  value: public/,private/internal/
 
+# Don't publish readme: these images aren't on Docker Hub.
 - name: publishReadme
   value: false
-# https://github.com/microsoft/go/issues/157 tracks enabling publishImageInfo.
+# Don't publish image info to https://github.com/dotnet/versions/tree/main/build-info
+# because the images aren't being published yet.
 - name: publishImageInfo
   value: false
 # https://github.com/microsoft/go/issues/192 tracks enabling ingestKustoImageInfo.
@@ -24,24 +30,68 @@ variables:
 
 - name: officialBranches
   # list multiple branches as "'branch1', 'branch2', etc."
-  value: "'main'"
+  value: main
 
 - name: manifest
   value: manifest.json
 
-# dotnet/versions repo path info is used in shared templates. Even though we aren't publishing
-# there, it needs to be specified to avoid pipeline errors when the variable is referenced in tasks.
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - group: go-docker-common
+  - group: Dotnet-Docker-Secrets-WIF
+
+- name: acr.password
+  value: $(BotAccount-golang-docker-acr-bot-password)
+- name: acr.servicePrincipalPassword
+  value: $(GolangDockerBuild)
+
+# We don't use a different ACR for staging vs. non-staging images.
+- name: acr-staging.resourceGroup
+  value: $(acr.resourceGroup)
+- name: acr-staging.server
+  value: $(acr.server)
+- name: acr-staging.serviceConnectionName
+  value: $(acr.serviceConnectionName)
+- name: acr-staging.subscription
+  value: $(acr.subscription)
+# We don't host a public mirror. Note: an empty string is necessary so the
+# variable is defined and .NET Docker logic works.
+- name: public-mirror.server
+  value: ''
+
+- name: test.serviceConnectionName
+  value: $(acr.serviceConnectionName)
+- name: internal-mirror.serviceConnectionName
+  value: $(acr.serviceConnectionName)
+- name: build.serviceConnectionName
+  value: $(acr.serviceConnectionName)
+- name: publish.serviceConnectionName
+  value: $(acr.serviceConnectionName)
+- name: marStatus.serviceConnectionName
+  value: ''
+- name: kusto.serviceConnectionName
+  value: ''
+
+# Configuration for publishing the image-info JSON file.
+- name: commonVersionsImageInfoPath
+  value: build-info/microsoft/go-infra-images
+
+# Configure image-info publishing.
+# Copied from /eng/common/templates/variables/dotnet/build-test-publish.yml
 - name: gitHubVersionsRepoInfo.path
   value: ${{ variables.commonVersionsImageInfoPath }}
 - name: azdoVersionsRepoInfo.path
   value: ${{ variables.commonVersionsImageInfoPath }}
-
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-  - group: go-docker-common-nightly
-  - group: go-docker-secrets
-  - group: go-docker-shared-DotNet-Docker-Secrets
-
-- name: acr.password
-  value: $(BotAccount-golang-docker-acr-public-bot-password)
-- name: acr.servicePrincipalPassword
-  value: $(GolangDockerBuild)
+- name: gitHubVersionsRepoInfo.org
+  value: dotnet
+- name: gitHubVersionsRepoInfo.repo
+  value: versions
+- name: gitHubVersionsRepoInfo.branch
+  value: main
+- name: gitHubVersionsRepoInfo.path
+  value: ${{ variables.commonVersionsImageInfoPath }}
+- name: gitHubVersionsRepoInfo.accessToken
+  value: $(BotAccount-dotnet-docker-bot-PAT)
+- name: gitHubVersionsRepoInfo.userName
+  value: $(dotnetDockerBot.userName)
+- name: gitHubVersionsRepoInfo.email
+  value: $(dotnetDockerBot.email)

--- a/manifest.json
+++ b/manifest.json
@@ -2,13 +2,13 @@
   "readme": {
     "path": "README.md"
   },
-  "registry": "golangpublicimages.azurecr.io",
+  "registry": "mcr.microsoft.com",
   "variables": {},
   "includes": [],
   "repos": [
     {
-      "id": "prereqs",
-      "name": "go-infra-images/prereqs",
+      "id": "infra-images",
+      "name": "microsoft-go/infra-images",
       "images": [
         {
           "productVersion": "",

--- a/manifest.json
+++ b/manifest.json
@@ -16,12 +16,12 @@
           "platforms": [
             {
               "architecture": "amd64",
-              "dockerfile": "src/cbl-mariner/1.0/amd64/default",
+              "dockerfile": "src/cbl-mariner/2.0/amd64/default",
               "os": "linux",
-              "osVersion": "1.0",
+              "osVersion": "2.0",
               "tags": {
-                "cbl-mariner-1.0-amd64-default": {},
-                "cbl-mariner-1.0-amd64-default-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+                "cbl-mariner-2.0-amd64-default": {},
+                "cbl-mariner-2.0-amd64-default-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]
@@ -32,12 +32,12 @@
           "platforms": [
             {
               "architecture": "amd64",
-              "dockerfile": "src/cbl-mariner/1.0/amd64/fips",
+              "dockerfile": "src/cbl-mariner/2.0/amd64/fips",
               "os": "linux",
-              "osVersion": "1.0",
+              "osVersion": "2.0",
               "tags": {
-                "cbl-mariner-1.0-amd64-fips": {},
-                "cbl-mariner-1.0-amd64-fips-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+                "cbl-mariner-2.0-amd64-fips": {},
+                "cbl-mariner-2.0-amd64-fips-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]
@@ -48,12 +48,12 @@
           "platforms": [
             {
               "architecture": "arm64",
-              "dockerfile": "src/cbl-mariner/1.0/arm64/default",
+              "dockerfile": "src/cbl-mariner/2.0/arm64/default",
               "os": "linux",
-              "osVersion": "1.0",
+              "osVersion": "2.0",
               "tags": {
-                "cbl-mariner-1.0-arm64-default": {},
-                "cbl-mariner-1.0-arm64-default-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+                "cbl-mariner-2.0-arm64-default": {},
+                "cbl-mariner-2.0-arm64-default-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]
@@ -64,12 +64,12 @@
           "platforms": [
             {
               "architecture": "arm64",
-              "dockerfile": "src/cbl-mariner/1.0/arm64/fips",
+              "dockerfile": "src/cbl-mariner/2.0/arm64/fips",
               "os": "linux",
-              "osVersion": "1.0",
+              "osVersion": "2.0",
               "tags": {
-                "cbl-mariner-1.0-arm64-fips": {},
-                "cbl-mariner-1.0-arm64-fips-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+                "cbl-mariner-2.0-arm64-fips": {},
+                "cbl-mariner-2.0-arm64-fips-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]
@@ -80,12 +80,12 @@
           "platforms": [
             {
               "architecture": "amd64",
-              "dockerfile": "src/ubuntu/18.04/amd64/default",
+              "dockerfile": "src/ubuntu/20.04/amd64/default",
               "os": "linux",
-              "osVersion": "18.04",
+              "osVersion": "20.04",
               "tags": {
-                "ubuntu-18.04-amd64-default": {},
-                "ubuntu-18.04-amd64-default-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+                "ubuntu-20.04-amd64-default": {},
+                "ubuntu-20.04-amd64-default-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]

--- a/src/cbl-mariner/2.0/amd64/default/Dockerfile
+++ b/src/cbl-mariner/2.0/amd64/default/Dockerfile
@@ -1,4 +1,4 @@
-FROM cblmariner.azurecr.io/base/core:1.0
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 
 # Install dependencies needed to build, test, and longtest Go.
 RUN set -eux; \

--- a/src/cbl-mariner/2.0/amd64/fips/Dockerfile
+++ b/src/cbl-mariner/2.0/amd64/fips/Dockerfile
@@ -1,4 +1,4 @@
-FROM golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-1.0-arm64-default
+FROM mcr.microsoft.com/microsoft-go/infra-images:cbl-mariner-2.0-amd64-default
 
 # Enable Go FIPS mode, even if the container host isn't in an enabled mode.
 ENV GOLANG_FIPS=1

--- a/src/cbl-mariner/2.0/arm64/default/Dockerfile
+++ b/src/cbl-mariner/2.0/arm64/default/Dockerfile
@@ -1,4 +1,4 @@
-FROM cblmariner.azurecr.io/base/core:1.0
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 
 # Install dependencies needed to build, test, and longtest Go.
 RUN set -eux; \

--- a/src/cbl-mariner/2.0/arm64/fips/Dockerfile
+++ b/src/cbl-mariner/2.0/arm64/fips/Dockerfile
@@ -1,4 +1,4 @@
-FROM golangpublicimages.azurecr.io/go-infra-images/prereqs:cbl-mariner-1.0-amd64-default
+FROM mcr.microsoft.com/microsoft-go/infra-images:cbl-mariner-2.0-arm64-default
 
 # Enable Go FIPS mode, even if the container host isn't in an enabled mode.
 ENV GOLANG_FIPS=1

--- a/src/ubuntu/20.04/amd64/default/Dockerfile
+++ b/src/ubuntu/20.04/amd64/default/Dockerfile
@@ -1,25 +1,22 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
-# Based on https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/5c627c7ceeb94a58033cdc927f349b6ae8ffe333/src/ubuntu/18.04/amd64/Dockerfile
+# Based on https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/c4da7a7d44bb3e9c177d1a65127010f777b8987c/src/ubuntu/20.04/Dockerfile
 # Then modified to remove some unnecessary tools and include dependencies for Go long tests.
 
 # Install the base toolchain we need to build anything (clang, cmake, make and the like).
 RUN apt-get update \
     && apt-get install -y \
-        clang-3.9 \
+        cmake \
+        clang-12 \
         gdb \
-        liblldb-3.9-dev \
-        lldb-3.9 \
-        llvm-3.9 \
+        liblldb-12-dev \
+        lldb-12 \
+        llvm-12 \
         locales \
         make \
-        python-lldb-3.9 \
         sudo \
         wget \
-    && rm -rf /var/lib/apt/lists/* \
-    && wget https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.tar.gz \
-    && tar -xf cmake-3.10.2-Linux-x86_64.tar.gz --strip 1 -C /usr/local \
-    && rm cmake-3.10.2-Linux-x86_64.tar.gz
+    && rm -rf /var/lib/apt/lists/*
 
 # Install tools used by the AzDO build automation.
 RUN apt-get update \
@@ -29,6 +26,7 @@ RUN apt-get update \
         npm \
         tar \
         zip \
+        curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Go long test prerequisites.


### PR DESCRIPTION
* For https://github.com/microsoft/go-lab/issues/95

Split into a few commits:

`Update eng/common to docker-tools@4c5996456d` is a clean .NET Docker eng/common update. No need to review.

`Update to latest go-images infra, modify for go-infra-images` updates the pipelines and associated files to be compatible with the new eng/common, based on microsoft/go-images and https://github.com/microsoft/go-images/pull/336.

`Update manifest for MAR publish` makes this repo capable of publishing to MAR once https://github.com/microsoft/mcr/pull/3431 is also merged.

Finally, `Update to in-support base images, adjust FROM lines` fixes up the Dockerfiles. Mariner 1.0 base images can't be pulled anymore, so updating to 2.0 is needed to fix the build. I updated Ubuntu to 20.04 because we should. (I'm not sure if the package repositories are actually offline yet.) I updated the `FROM` statements to match the new MAR target.

Successful test build before a few rebases: https://dev.azure.com/dnceng/internal/_build/results?buildId=2525338&view=results
Fresh test build (in progress as of writing): https://dev.azure.com/dnceng/internal/_build/results?buildId=2525458&view=results