### PR TITLE
Add Azure Linux 3 Docker image

### DIFF
--- a/cmd/geninfra/main.go
+++ b/cmd/geninfra/main.go
@@ -59,7 +59,7 @@ func run(cmd *cobra.Command, args []string) error {
 
 		var os string
 		switch distro {
-		case "cbl-mariner", "debian", "ubuntu":
+		case "cbl-mariner", "debian", "ubuntu", "azurelinux":
 			os = "linux"
 		default:
 			log.Printf("Didn't recognize distro, update %v: %v\n", "cmd/gen/main.go", distro)

--- a/images.md
+++ b/images.md
@@ -8,6 +8,11 @@ If a build hasn't occurred yet, the list may be out of date.
 
 For an accurate but harder to use list of currently available tags, see [the list API](https://mcr.microsoft.com/v2/microsoft-go/infra-images/tags/list).
 
+`azurelinux-3.0-amd64-default` ([src/azurelinux/3.0/amd64/default](./src/azurelinux/3.0/amd64/default/Dockerfile))
+```
+mcr.microsoft.com/microsoft-go/infra-images:azurelinux-3.0-amd64-default
+```
+
 `cbl-mariner-2.0-amd64-default` ([src/cbl-mariner/2.0/amd64/default](./src/cbl-mariner/2.0/amd64/default/Dockerfile))
 ```
 mcr.microsoft.com/microsoft-go/infra-images:cbl-mariner-2.0-amd64-default

--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,22 @@
           "platforms": [
             {
               "architecture": "amd64",
+              "dockerfile": "src/azurelinux/3.0/amd64/default",
+              "os": "linux",
+              "osVersion": "3.0",
+              "tags": {
+                "azurelinux-3.0-amd64-default": {},
+                "azurelinux-3.0-amd64-default-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "",
+          "sharedTags": {},
+          "platforms": [
+            {
+              "architecture": "amd64",
               "dockerfile": "src/cbl-mariner/2.0/amd64/default",
               "os": "linux",
               "osVersion": "2.0",

--- a/src/azurelinux/3.0/amd64/default/Dockerfile
+++ b/src/azurelinux/3.0/amd64/default/Dockerfile
@@ -1,0 +1,22 @@
+# mcr.microsoft.com/azurelinux/base/core:3.0 doesn't distribute a PowerShell package,
+# see https://github.com/microsoft/azurelinux/pull/2799.
+# Use the .NET SDK image as a base image instead, which includes PowerShell and
+# the necessary dependencies to use it (i.e. .NET Runtime and .NET SDK).
+FROM mcr.microsoft.com/dotnet/sdk:9.0-azurelinux3.0-amd64
+
+# Install dependencies needed to build, test, and longtest Go.
+RUN set -eux; \
+    # Upgrade all packages per https://eng.ms/docs/more/containers-secure-supply-chain/updating.
+	tdnf update -y; \
+    tdnf install -y \
+        binutils \
+        ca-certificates \
+        gcc \
+        git \
+        glibc \
+        glibc-devel \
+        iana-etc \
+        kernel-headers \
+        mercurial \
+    ; \
+    tdnf clean all


### PR DESCRIPTION
This new Docker image will be used to test the Microsoft Go toolchain in Azure Linux.