### PR TITLE
Install sudo in Azure Linux 3

### DIFF
--- a/src/azurelinux/3.0/amd64/default/Dockerfile
+++ b/src/azurelinux/3.0/amd64/default/Dockerfile
@@ -18,5 +18,6 @@ RUN set -eux; \
         iana-etc \
         kernel-headers \
         mercurial \
+        sudo \
     ; \
     tdnf clean all


### PR DESCRIPTION
Azure Pipelines requires `sudo` but Azure Linux 3 doesn't provide it by default. Install it in our Docker image.