### PR TITLE
Pull ubuntu from ACR

### DIFF
--- a/src/ubuntu/20.04/amd64/default/Dockerfile
+++ b/src/ubuntu/20.04/amd64/default/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu.azurecr.io/ubuntu:20.04
 
 # Based on https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/c4da7a7d44bb3e9c177d1a65127010f777b8987c/src/ubuntu/20.04/Dockerfile
 # Then modified to remove some unnecessary tools and include dependencies for Go long tests.


### PR DESCRIPTION
The PR pipeline currently complains about Ubuntu being pulled from an unapproved third part registry:

https://dev.azure.com/dnceng/internal/_build/results?buildId=2568015&view=logs&j=91148dad-8242-58a1-d104-2874ea6ecbb1&t=03c0f159-c37d-515b-763f-cdf6ea1ffff7&l=21.

This PR switches the image reference from Docker to ACR.