### PR TITLE
Install sudo and Mariner 2 and remove FIPS variant

### DIFF
--- a/images.md
+++ b/images.md
@@ -18,19 +18,9 @@ mcr.microsoft.com/microsoft-go/infra-images:azurelinux-3.0-amd64-default
 mcr.microsoft.com/microsoft-go/infra-images:cbl-mariner-2.0-amd64-default
 ```
 
-`cbl-mariner-2.0-amd64-fips` ([src/cbl-mariner/2.0/amd64/fips](./src/cbl-mariner/2.0/amd64/fips/Dockerfile))
-```
-mcr.microsoft.com/microsoft-go/infra-images:cbl-mariner-2.0-amd64-fips
-```
-
 `cbl-mariner-2.0-arm64-default` ([src/cbl-mariner/2.0/arm64/default](./src/cbl-mariner/2.0/arm64/default/Dockerfile))
 ```
 mcr.microsoft.com/microsoft-go/infra-images:cbl-mariner-2.0-arm64-default
-```
-
-`cbl-mariner-2.0-arm64-fips` ([src/cbl-mariner/2.0/arm64/fips](./src/cbl-mariner/2.0/arm64/fips/Dockerfile))
-```
-mcr.microsoft.com/microsoft-go/infra-images:cbl-mariner-2.0-arm64-fips
 ```
 
 `ubuntu-20.04-amd64-default` ([src/ubuntu/20.04/amd64/default](./src/ubuntu/20.04/amd64/default/Dockerfile))

--- a/manifest.json
+++ b/manifest.json
@@ -47,22 +47,6 @@
           "sharedTags": {},
           "platforms": [
             {
-              "architecture": "amd64",
-              "dockerfile": "src/cbl-mariner/2.0/amd64/fips",
-              "os": "linux",
-              "osVersion": "2.0",
-              "tags": {
-                "cbl-mariner-2.0-amd64-fips": {},
-                "cbl-mariner-2.0-amd64-fips-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
-              }
-            }
-          ]
-        },
-        {
-          "productVersion": "",
-          "sharedTags": {},
-          "platforms": [
-            {
               "architecture": "arm64",
               "dockerfile": "src/cbl-mariner/2.0/arm64/default",
               "os": "linux",
@@ -70,22 +54,6 @@
               "tags": {
                 "cbl-mariner-2.0-arm64-default": {},
                 "cbl-mariner-2.0-arm64-default-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
-              }
-            }
-          ]
-        },
-        {
-          "productVersion": "",
-          "sharedTags": {},
-          "platforms": [
-            {
-              "architecture": "arm64",
-              "dockerfile": "src/cbl-mariner/2.0/arm64/fips",
-              "os": "linux",
-              "osVersion": "2.0",
-              "tags": {
-                "cbl-mariner-2.0-arm64-fips": {},
-                "cbl-mariner-2.0-arm64-fips-$(System:TimeStamp)-$(System:DockerfileGitCommitSha)": {}
               }
             }
           ]

--- a/src/cbl-mariner/2.0/amd64/default/Dockerfile
+++ b/src/cbl-mariner/2.0/amd64/default/Dockerfile
@@ -14,7 +14,7 @@ RUN set -eux; \
         iana-etc \
         kernel-headers \
         mercurial \
-        openssl-devel \
         powershell \
+        sudo \
     ; \
     tdnf clean all

--- a/src/cbl-mariner/2.0/amd64/fips/Dockerfile
+++ b/src/cbl-mariner/2.0/amd64/fips/Dockerfile
@@ -1,4 +1,0 @@
-FROM mcr.microsoft.com/microsoft-go/infra-images:cbl-mariner-2.0-amd64-default
-
-# Enable Go FIPS mode, even if the container host isn't in an enabled mode.
-ENV GOLANG_FIPS=1

--- a/src/cbl-mariner/2.0/arm64/default/Dockerfile
+++ b/src/cbl-mariner/2.0/arm64/default/Dockerfile
@@ -14,7 +14,7 @@ RUN set -eux; \
         iana-etc \
         kernel-headers \
         mercurial \
-        openssl-devel \
         powershell \
+        sudo \
     ; \
     tdnf clean all

--- a/src/cbl-mariner/2.0/arm64/fips/Dockerfile
+++ b/src/cbl-mariner/2.0/arm64/fips/Dockerfile
@@ -1,4 +1,0 @@
-FROM mcr.microsoft.com/microsoft-go/infra-images:cbl-mariner-2.0-arm64-default
-
-# Enable Go FIPS mode, even if the container host isn't in an enabled mode.
-ENV GOLANG_FIPS=1


### PR DESCRIPTION
Azure Pipelines requires `sudo` but Mariner 2 doesn't provide it by default. Install it in our Docker image.

While here, remove the Mariner 2 FIPS variants, they are not used anywhere as we enable FIPS mode at runtime when needed.
Also, remove the `openssl-devel` package. It was initially required by our OpenSSL backend, but it hasn't been necessary since long time ago.

For https://github.com/microsoft/go/issues/1371.