### PR TITLE
Install `su` on Mariner 2

### DIFF
--- a/src/cbl-mariner/2.0/amd64/default/Dockerfile
+++ b/src/cbl-mariner/2.0/amd64/default/Dockerfile
@@ -6,6 +6,7 @@ RUN set -eux; \
 	tdnf update -y; \
     tdnf install -y \
         binutils \
+        util-linux \
         ca-certificates-microsoft \
         gcc \
         git \

--- a/src/cbl-mariner/2.0/arm64/default/Dockerfile
+++ b/src/cbl-mariner/2.0/arm64/default/Dockerfile
@@ -6,6 +6,7 @@ RUN set -eux; \
 	tdnf update -y; \
     tdnf install -y \
         binutils \
+        util-linux \
         ca-certificates-microsoft \
         gcc \
         git \


### PR DESCRIPTION
Azure Pipelines requires `su` but Mariner 2 doesn't provide it by default. Install it in our Docker image.