### PR TITLE
Install `tar` in Mariner 2

### DIFF
--- a/src/cbl-mariner/2.0/amd64/default/Dockerfile
+++ b/src/cbl-mariner/2.0/amd64/default/Dockerfile
@@ -17,5 +17,6 @@ RUN set -eux; \
         mercurial \
         powershell \
         sudo \
+        tar \
     ; \
     tdnf clean all

--- a/src/cbl-mariner/2.0/arm64/default/Dockerfile
+++ b/src/cbl-mariner/2.0/arm64/default/Dockerfile
@@ -17,5 +17,6 @@ RUN set -eux; \
         mercurial \
         powershell \
         sudo \
+        tar \
     ; \
     tdnf clean all


### PR DESCRIPTION
Azure Pipelines requires `tar` but Mariner 2 doesn't provide it by default. Install it in our Docker image.