### PR TITLE
Run `go mod tidy`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/go-infra-images
 
-go 1.19
+go 1.22.0
 
 require (
 	github.com/microsoft/go-infra v0.0.6


### PR DESCRIPTION
Our AzDO pipelines are complaining about the `go.mod` file not being tidy. Running `go mod tidy` should fix this issue.