### PR TITLE
Remove cobra dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,6 @@ module github.com/microsoft/go-infra-images
 
 go 1.22.0
 
-require (
-	github.com/microsoft/go-infra v0.0.6
-	github.com/spf13/cobra v1.8.1
-)
+require github.com/microsoft/go-infra v0.0.6
 
-require (
-	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/text v0.21.0 // indirect
-)
+require golang.org/x/text v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,14 +1,4 @@
-github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
-github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
-github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/microsoft/go-infra v0.0.6 h1:RB/Jx3bMC8I+16Ra9iy+HcrHe3Ss1iM46OZ0LzNUZ0Y=
 github.com/microsoft/go-infra v0.0.6/go.mod h1:L+TMMmm7bkfgUfx1FZmReNHXL9m4oqvc+bVXCuaKD30=
-github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
-github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
-github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
 golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This repo uses `github.com/spf13/cobra` only to define a simple parameter-less command. We can replace it for the `flag` package from the standard library. The main benefit is less Dependabot churn.