### PR TITLE
Don't depend on github.com/microsoft/go-infra/stringutil

### DIFF
--- a/cmd/geninfra/main.go
+++ b/cmd/geninfra/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io/fs"
@@ -13,7 +14,6 @@ import (
 	"strings"
 
 	"github.com/microsoft/go-infra/buildmodel/dockermanifest"
-	"github.com/microsoft/go-infra/stringutil"
 )
 
 const description = `
@@ -124,11 +124,20 @@ func run() error {
 		},
 	}
 
-	if err := stringutil.WriteJSONFile("manifest.json", m); err != nil {
+	if err := writeJSONFile("manifest.json", m); err != nil {
 		return err
 	}
 
 	return writeImagesMD(m)
+}
+
+// writeJSONFile writes one specified value to a file as indented JSON with a trailing newline.
+func writeJSONFile(path string, i interface{}) (err error) {
+	out, err := json.MarshalIndent(i, "", "  ")
+	if err != nil {
+		return fmt.Errorf("unable to marshal model into JSON: %w", err)
+	}
+	return os.WriteFile(path, append(out, '\n'), 0o666)
 }
 
 func writeImagesMD(m *dockermanifest.Manifest) error {

--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,3 @@ module github.com/microsoft/go-infra-images
 go 1.22.0
 
 require github.com/microsoft/go-infra v0.0.6
-
-require golang.org/x/text v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
 github.com/microsoft/go-infra v0.0.6 h1:RB/Jx3bMC8I+16Ra9iy+HcrHe3Ss1iM46OZ0LzNUZ0Y=
 github.com/microsoft/go-infra v0.0.6/go.mod h1:L+TMMmm7bkfgUfx1FZmReNHXL9m4oqvc+bVXCuaKD30=
-golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
-golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=


### PR DESCRIPTION
We shouldn't depend on `github.com/microsoft/go-infra/stringutil` for a function that only takes 4 lines and that is not dark magic.

Dropping it safe us from indirectly requiring `golang.org/x/text`.