### PR TITLE
Update area path in tsaoptions.json

### DIFF
--- a/.config/tsa/tsaoptions.json
+++ b/.config/tsa/tsaoptions.json
@@ -8,7 +8,7 @@
   ],
   "instanceUrl": "https://devdiv.visualstudio.com/",
   "projectName": "DEVDIV",
-  "areaPath": "DevDiv\\NET Compilers\\GoLang",
+  "areaPath": "DevDiv\\GoLang",
   "iterationPath": "DevDiv",
   "allTools": true
 }


### PR DESCRIPTION
Some BinSkim issues have been showing up in Jared's area path, moving them to the non-dotnet spcific area path.