### PR TITLE
Add simple CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Require review from golang-compiler team for changes in all files.
+
+* @microsoft/golang-compiler


### PR DESCRIPTION
Copy https://github.com/microsoft/go-images/blob/microsoft/main/.github/CODEOWNERS, but files aren't automatically updated in this repo, so simplify.