### PR TITLE
Retain official builds via custom matrix-gen init step

### DIFF
--- a/eng/pipeline/go-infra-images-rolling-internal-pipeline-unofficial.yml
+++ b/eng/pipeline/go-infra-images-rolling-internal-pipeline-unofficial.yml
@@ -65,6 +65,7 @@ extends:
             versionsRepoRef: VersionsRepo
             noCache: true
             customGenerateMatrixInitSteps:
+              - template: /eng/pipeline/steps/set-retain-build-var.yml@self
               - template: /eng/pipeline/steps/set-public-source-branch-var.yml@self
             customBuildInitSteps:
               - template: /eng/pipeline/steps/set-imagebuilder-build-args-var.yml@self

--- a/eng/pipeline/go-infra-images-rolling-internal-pipeline.yml
+++ b/eng/pipeline/go-infra-images-rolling-internal-pipeline.yml
@@ -75,6 +75,7 @@ extends:
             versionsRepoRef: VersionsRepo
             noCache: true
             customGenerateMatrixInitSteps:
+              - template: /eng/pipeline/steps/set-retain-build-var.yml@self
               - template: /eng/pipeline/steps/set-public-source-branch-var.yml@self
             customBuildInitSteps:
               - template: /eng/pipeline/steps/set-imagebuilder-build-args-var.yml@self

--- a/eng/pipeline/go-infra-images-rolling-internal.gen.yml
+++ b/eng/pipeline/go-infra-images-rolling-internal.gen.yml
@@ -95,6 +95,7 @@ extends:
             versionsRepoRef: VersionsRepo
             noCache: true
             customGenerateMatrixInitSteps:
+              - template: /eng/pipeline/steps/set-retain-build-var.yml@self
               - template: /eng/pipeline/steps/set-public-source-branch-var.yml@self
             customBuildInitSteps:
               - template: /eng/pipeline/steps/set-imagebuilder-build-args-var.yml@self

--- a/eng/pipeline/steps/set-retain-build-var.yml
+++ b/eng/pipeline/steps/set-retain-build-var.yml
@@ -1,0 +1,44 @@
+# Compute the "retainBuild" pipeline variable consumed by the docker-tools
+# retain-build step (eng/docker-tools/templates/steps/retain-build.yml). When
+# this variable is set to the string "true", the docker-tools step calls
+# Retain-Build.ps1 to mark the build with keepForever=true.
+#
+# We compute it here (outside of eng/docker-tools) because that directory is
+# synced from dotnet/docker-tools and any local edits would be overwritten.
+#
+# Retention triggers when:
+#   - the caller explicitly passed retainBuild=true as a queue-time variable, or
+#   - this is an official pipeline definition AND the source branch matches one
+#     of the configured official branches/prefixes.
+steps:
+- powershell: |
+    # Use the 1ESPT-provided ONEESPT_BUILDTYPE env var as the source of truth
+    # for official vs unofficial, matching how docker-tools' validate-branch.yml
+    # and set-dry-run.yml decide. The Build.DefinitionName suffix convention is
+    # human-set and case-sensitive, so relying on it can permanently retain
+    # builds from an unofficial pipeline with a non-conforming name.
+    $isOfficialDefinition = "$env:ONEESPT_BUILDTYPE" -ne "Unofficial"
+    $officialBranchList = "$(officialBranches)"
+    $sourceBranch = "$(sourceBranch)"
+    $officialBranchPrefixes = "$(officialBranchPrefixes)"
+
+    $isOfficialBranch = $officialBranchList.Split(',').Trim() -contains $sourceBranch
+    $hasOfficialPrefix = $false
+    foreach ($prefix in $officialBranchPrefixes.Split(',').Trim() | Where-Object { $_ }) {
+      if ($sourceBranch.StartsWith($prefix)) {
+        $hasOfficialPrefix = $true
+        break
+      }
+    }
+
+    # Retain when explicitly requested or when this is an official branch build.
+    $retainBuildOverride = "$env:RETAIN_BUILD_OVERRIDE".Trim().ToLowerInvariant()
+    $retainBuild = ($retainBuildOverride -eq "true") -or ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix))
+    $retainBuildValue = if ($retainBuild) { "true" } else { "false" }
+
+    echo "##vso[task.setvariable variable=retainBuild]$retainBuildValue"
+    Write-Host "retainBuild set to: $retainBuildValue (official def: $isOfficialDefinition, official branch: $isOfficialBranch, has prefix: $hasOfficialPrefix)"
+  env:
+    RETAIN_BUILD_OVERRIDE: $(retainBuild)
+  displayName: Compute retention decision
+  condition: succeeded()


### PR DESCRIPTION
Mirror of microsoft/go-images change. Compute retainBuild outside eng/docker-tools (which is synced from dotnet/docker-tools) and inject the new step into customGenerateMatrixInitSteps so the synced retain-build.yml picks it up. Retention runs once in the matrix-gen job which is enough to mark the entire build with keepForever=true. Generated output files were updated by hand because 'go generate ./eng/pipeline' currently fails on this repo at go-infra-images-rolling-internal.gen.yml:18 with 'inlineif without inlineelse cannot appear as a mapping value' (pre-existing issue on origin/main, unrelated to this change).

- https://github.com/microsoft/go-images/pull/610
- https://github.com/microsoft/go-lab/issues/59