### PR TITLE
Add pipeline descriptions, fix invalid gen.yml

### DIFF
--- a/eng/pipeline/go-infra-images-pr-pipeline.yml
+++ b/eng/pipeline/go-infra-images-pr-pipeline.yml
@@ -1,4 +1,9 @@
-trigger: none
+# Copyright (c) Microsoft Corporation.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# public: https://dev.azure.com/dnceng-public/public/_build?definitionId=211
+
 pr:
   branches:
     include:

--- a/eng/pipeline/go-infra-images-pr-pipeline.yml
+++ b/eng/pipeline/go-infra-images-pr-pipeline.yml
@@ -4,6 +4,7 @@
 
 # public: https://dev.azure.com/dnceng-public/public/_build?definitionId=211
 
+trigger: none
 pr:
   branches:
     include:

--- a/eng/pipeline/go-infra-images-rolling-internal-pipeline-unofficial.yml
+++ b/eng/pipeline/go-infra-images-rolling-internal-pipeline-unofficial.yml
@@ -5,24 +5,35 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-# This pipeline builds and publishes Go infra images on a rolling basis.
-
 # official: https://dev.azure.com/dnceng/internal/_build?definitionId=1170
 # unofficial: https://dev.azure.com/dnceng/internal/_build?definitionId=1515
 
-trigger: {}
+trigger: none
 pr: none
 schedules: []
 parameters:
+  - name: _info
+    displayName: >
+      ℹ️ This pipeline builds and publishes the infrastructure images we use to test
+      the Microsoft build of Go, its crypto backends, and other related components.
+      These images do not include the Microsoft build of Go itself.
+
+    type: string
+    values:
+      - "\U0001F535  go-infra-images-rolling-internal-pipeline-unofficial.yml  \U0001F535
+        \U0001F535"
   - name: sourceBuildPipelineRunId
     displayName: >
-      The build ID of this pipeline to publish images from. Use the default value when building new images.
+      The run ID (build ID) that produced the images that this run should publish.
+      Use the default value to build and publish new images during this run.
 
     type: string
     default: '$(Build.BuildId)'
   - name: publishRepoPrefix
     displayName: >
-      Publish repo prefix to use when publishing images. Switch to "dev/" for an unofficial branch.
+      The repo prefix to use when publishing images to the intermediate ACR. Use "unlisted/"
+      when building an official branch. Use "dev/" when building an unofficial or
+      custom branch that shouldn't be published to MAR.
 
     type: string
     default: dev/

--- a/eng/pipeline/go-infra-images-rolling-internal-pipeline-unofficial.yml
+++ b/eng/pipeline/go-infra-images-rolling-internal-pipeline-unofficial.yml
@@ -13,15 +13,14 @@ pr: none
 schedules: []
 parameters:
   - name: _info
-    displayName: >
-      ℹ️ This pipeline builds and publishes the infrastructure images we use to test
-      the Microsoft build of Go, its crypto backends, and other related components.
-      These images do not include the Microsoft build of Go itself.
-
+    displayName: |
+      ℹ️ This pipeline builds and publishes the infrastructure images we use to test the Microsoft build of Go, its crypto backends, and other related components. These images do not include the Microsoft build of Go itself.
     type: string
     values:
       - "\U0001F535  go-infra-images-rolling-internal-pipeline-unofficial.yml  \U0001F535
         \U0001F535"
+    default: "\U0001F535  go-infra-images-rolling-internal-pipeline-unofficial.yml
+      \ \U0001F535 \U0001F535"
   - name: sourceBuildPipelineRunId
     displayName: >
       The run ID (build ID) that produced the images that this run should publish.

--- a/eng/pipeline/go-infra-images-rolling-internal-pipeline.yml
+++ b/eng/pipeline/go-infra-images-rolling-internal-pipeline.yml
@@ -23,14 +23,13 @@ schedules:
     always: true
 parameters:
   - name: _info
-    displayName: >
-      ℹ️ This pipeline builds and publishes the infrastructure images we use to test
-      the Microsoft build of Go, its crypto backends, and other related components.
-      These images do not include the Microsoft build of Go itself.
-
+    displayName: |
+      ℹ️ This pipeline builds and publishes the infrastructure images we use to test the Microsoft build of Go, its crypto backends, and other related components. These images do not include the Microsoft build of Go itself.
     type: string
     values:
       - "\U0001F535  go-infra-images-rolling-internal-pipeline.yml  \U0001F535 \U0001F535"
+    default: "\U0001F535  go-infra-images-rolling-internal-pipeline.yml  \U0001F535
+      \U0001F535"
   - name: sourceBuildPipelineRunId
     displayName: >
       The run ID (build ID) that produced the images that this run should publish.

--- a/eng/pipeline/go-infra-images-rolling-internal-pipeline.yml
+++ b/eng/pipeline/go-infra-images-rolling-internal-pipeline.yml
@@ -5,8 +5,6 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-# This pipeline builds and publishes Go infra images on a rolling basis.
-
 # official: https://dev.azure.com/dnceng/internal/_build?definitionId=1170
 # unofficial: https://dev.azure.com/dnceng/internal/_build?definitionId=1515
 
@@ -24,15 +22,27 @@ schedules:
         - main
     always: true
 parameters:
+  - name: _info
+    displayName: >
+      ℹ️ This pipeline builds and publishes the infrastructure images we use to test
+      the Microsoft build of Go, its crypto backends, and other related components.
+      These images do not include the Microsoft build of Go itself.
+
+    type: string
+    values:
+      - "\U0001F535  go-infra-images-rolling-internal-pipeline.yml  \U0001F535 \U0001F535"
   - name: sourceBuildPipelineRunId
     displayName: >
-      The build ID of this pipeline to publish images from. Use the default value when building new images.
+      The run ID (build ID) that produced the images that this run should publish.
+      Use the default value to build and publish new images during this run.
 
     type: string
     default: '$(Build.BuildId)'
   - name: publishRepoPrefix
     displayName: >
-      Publish repo prefix to use when publishing images. Switch to "dev/" for an unofficial branch.
+      The repo prefix to use when publishing images to the intermediate ACR. Use "unlisted/"
+      when building an official branch. Use "dev/" when building an unofficial or
+      custom branch that shouldn't be published to MAR.
 
     type: string
     default: unlisted/

--- a/eng/pipeline/go-infra-images-rolling-internal.gen.yml
+++ b/eng/pipeline/go-infra-images-rolling-internal.gen.yml
@@ -2,8 +2,6 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-# This pipeline builds and publishes Go infra images on a rolling basis.
-
 # official: https://dev.azure.com/dnceng/internal/_build?definitionId=1170
 # unofficial: https://dev.azure.com/dnceng/internal/_build?definitionId=1515
 
@@ -23,6 +21,8 @@ trigger:
     branches:
       include:
         - main
+  ${ inlineelse }:
+    none
 pr: none
 schedules:
   - ${ inlineif .official }:
@@ -34,17 +34,27 @@ schedules:
       always: true
 
 parameters:
+  - name: _info
+    displayName: >
+      ℹ️ This pipeline builds and publishes the infrastructure images we use to test the Microsoft
+      build of Go, its crypto backends, and other related components. These images do not include
+      the Microsoft build of Go itself.
+    type: string
+    values:
+      - ${ cat "🔵 " .output " 🔵 🔵" }
+
   - name: sourceBuildPipelineRunId
     displayName: >
-      The build ID of this pipeline to publish images from.
-      Use the default value when building new images.
+      The run ID (build ID) that produced the images that this run should publish. Use the default
+      value to build and publish new images during this run.
     type: string
     default: '$(Build.BuildId)'
 
   - name: publishRepoPrefix
     displayName: >
-      Publish repo prefix to use when publishing images.
-      Switch to "dev/" for an unofficial branch.
+      The repo prefix to use when publishing images to the intermediate ACR.
+      Use "unlisted/" when building an official branch.
+      Use "dev/" when building an unofficial or custom branch that shouldn't be published to MAR.
     type: string
     default:
       ${ inlineif .official }: 'unlisted/'

--- a/eng/pipeline/go-infra-images-rolling-internal.gen.yml
+++ b/eng/pipeline/go-infra-images-rolling-internal.gen.yml
@@ -34,14 +34,11 @@ schedules:
       always: true
 
 parameters:
-  - name: _info
-    displayName: >
-      ℹ️ This pipeline builds and publishes the infrastructure images we use to test the Microsoft
-      build of Go, its crypto backends, and other related components. These images do not include
-      the Microsoft build of Go itself.
-    type: string
-    values:
-      - ${ cat "🔵 " .output " 🔵 🔵" }
+  - ${ inlinetemplate "util/info.gen.yml" }:
+      desc: >
+        This pipeline builds and publishes the infrastructure images we use to test the Microsoft
+        build of Go, its crypto backends, and other related components. These images do not include
+        the Microsoft build of Go itself.
 
   - name: sourceBuildPipelineRunId
     displayName: >

--- a/eng/pipeline/rolling-internal-validation-pipeline-unofficial.yml
+++ b/eng/pipeline/rolling-internal-validation-pipeline-unofficial.yml
@@ -5,23 +5,32 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-# This pipeline runs rolling validation, like CodeQL.
-
 # official: https://dev.azure.com/dnceng/internal/_build?definitionId=1358
 # unofficial: https://dev.azure.com/dnceng/internal/_build?definitionId=1516
 
 trigger: none
 pr: none
-# For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
 parameters:
+  - name: _info
+    displayName: ℹ️ This pipeline runs rolling validation, like CodeQL.
+    type: string
+    values:
+      - "\U0001F535  rolling-internal-validation-pipeline-unofficial.yml  \U0001F535
+        \U0001F535"
   - name: enableCodeQL
-    displayName: '[Debug input] Enable CodeQL, even on a dev branch.'
+    displayName: >
+      [Debug input] Force CodeQL to run, ignoring its built-in skip cadence. Use this
+      to try modifications in dev branches.
+
     type: boolean
-    default: true
+    default: false
   - name: disableTSA
-    displayName: '[Debug input] Disable TSA reporting. Use to try modifications in dev branches.'
+    displayName: >
+      [Debug input] Skip TSA reporting. Use when running a dev branch. This lets you
+      avoid triggering false positive TSA notifications when testing out new modifications.
+
     type: boolean
-    default: true
+    default: false
 variables:
   - name: Codeql.PublishDatabase
     value: true

--- a/eng/pipeline/rolling-internal-validation-pipeline-unofficial.yml
+++ b/eng/pipeline/rolling-internal-validation-pipeline-unofficial.yml
@@ -17,6 +17,8 @@ parameters:
     values:
       - "\U0001F535  rolling-internal-validation-pipeline-unofficial.yml  \U0001F535
         \U0001F535"
+    default: "\U0001F535  rolling-internal-validation-pipeline-unofficial.yml  \U0001F535
+      \U0001F535"
   - name: enableCodeQL
     displayName: >
       [Debug input] Force CodeQL to run, ignoring its built-in skip cadence. Use this

--- a/eng/pipeline/rolling-internal-validation-pipeline.yml
+++ b/eng/pipeline/rolling-internal-validation-pipeline.yml
@@ -16,6 +16,7 @@ parameters:
     type: string
     values:
       - "\U0001F535  rolling-internal-validation-pipeline.yml  \U0001F535 \U0001F535"
+    default: "\U0001F535  rolling-internal-validation-pipeline.yml  \U0001F535 \U0001F535"
   - name: enableCodeQL
     displayName: >
       [Debug input] Force CodeQL to run, ignoring its built-in skip cadence. Use this

--- a/eng/pipeline/rolling-internal-validation-pipeline.yml
+++ b/eng/pipeline/rolling-internal-validation-pipeline.yml
@@ -5,21 +5,29 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-# This pipeline runs rolling validation, like CodeQL.
-
 # official: https://dev.azure.com/dnceng/internal/_build?definitionId=1358
 # unofficial: https://dev.azure.com/dnceng/internal/_build?definitionId=1516
 
 trigger: none
 pr: none
-# For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
 parameters:
+  - name: _info
+    displayName: ℹ️ This pipeline runs rolling validation, like CodeQL.
+    type: string
+    values:
+      - "\U0001F535  rolling-internal-validation-pipeline.yml  \U0001F535 \U0001F535"
   - name: enableCodeQL
-    displayName: '[Debug input] Enable CodeQL, even on a dev branch.'
+    displayName: >
+      [Debug input] Force CodeQL to run, ignoring its built-in skip cadence. Use this
+      to try modifications in dev branches.
+
     type: boolean
     default: false
   - name: disableTSA
-    displayName: '[Debug input] Disable TSA reporting. Use to try modifications in dev branches.'
+    displayName: >
+      [Debug input] Skip TSA reporting. Use when running a dev branch. This lets you
+      avoid triggering false positive TSA notifications when testing out new modifications.
+
     type: boolean
     default: false
 variables:

--- a/eng/pipeline/rolling-internal-validation.gen.yml
+++ b/eng/pipeline/rolling-internal-validation.gen.yml
@@ -19,11 +19,8 @@ trigger: none
 pr: none
 
 parameters:
-  - name: _info
-    displayName: ℹ️ This pipeline runs rolling validation, like CodeQL.
-    type: string
-    values:
-      - ${ cat "🔵 " .output " 🔵 🔵" }
+  - ${ inlinetemplate "util/info.gen.yml" }:
+      desc: This pipeline runs rolling validation, like CodeQL.
 
   - name: enableCodeQL
     displayName: >

--- a/eng/pipeline/rolling-internal-validation.gen.yml
+++ b/eng/pipeline/rolling-internal-validation.gen.yml
@@ -2,8 +2,6 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-# This pipeline runs rolling validation, like CodeQL.
-
 # official: https://dev.azure.com/dnceng/internal/_build?definitionId=1358
 # unofficial: https://dev.azure.com/dnceng/internal/_build?definitionId=1516
 
@@ -20,17 +18,26 @@ pipelineymlgen:
 trigger: none
 pr: none
 
-# For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
 parameters:
+  - name: _info
+    displayName: ℹ️ This pipeline runs rolling validation, like CodeQL.
+    type: string
+    values:
+      - ${ cat "🔵 " .output " 🔵 🔵" }
+
   - name: enableCodeQL
-    displayName: '[Debug input] Enable CodeQL, even on a dev branch.'
+    displayName: >
+      [Debug input] Force CodeQL to run, ignoring its built-in skip cadence. Use this to try
+      modifications in dev branches.
     type: boolean
-    default: ${ yml (not .official) }
+    default: false
 
   - name: disableTSA
-    displayName: '[Debug input] Disable TSA reporting. Use to try modifications in dev branches.'
+    displayName: >
+      [Debug input] Skip TSA reporting. Use when running a dev branch. This lets you avoid
+      triggering false positive TSA notifications when testing out new modifications.
     type: boolean
-    default: ${ yml (not .official) }
+    default: false
 
 variables:
   - name: Codeql.PublishDatabase

--- a/eng/pipeline/stages/publish-config-nonprod.yml
+++ b/eng/pipeline/stages/publish-config-nonprod.yml
@@ -56,7 +56,8 @@ stages:
           repoPrefix: $(publicMirrorRepoPrefix)
         BuildRegistry:
           server: $(acr-staging-test.server)
-          repoPrefix: "${{ parameters.stagingRepoPrefix }}${{ parameters.sourceBuildPipelineRunId }}/"
+          repoPrefix: "${{ parameters.stagingRepoPrefix }}${{ parameters.sourceBuildPipelineRunId
+            }}/"
         PublishRegistry:
           server: $(acr-test.server)
           repoPrefix: "${{ parameters.publishRepoPrefix }}"

--- a/eng/pipeline/stages/publish-config-prod.yml
+++ b/eng/pipeline/stages/publish-config-prod.yml
@@ -56,7 +56,8 @@ stages:
           repoPrefix: $(publicMirrorRepoPrefix)
         BuildRegistry:
           server: $(acr-staging.server)
-          repoPrefix: "${{ parameters.stagingRepoPrefix }}${{ parameters.sourceBuildPipelineRunId }}/"
+          repoPrefix: "${{ parameters.stagingRepoPrefix }}${{ parameters.sourceBuildPipelineRunId
+            }}/"
         PublishRegistry:
           server: $(acr.server)
           repoPrefix: "${{ parameters.publishRepoPrefix }}"

--- a/eng/pipeline/util/info.gen.yml
+++ b/eng/pipeline/util/info.gen.yml
@@ -1,0 +1,26 @@
+# Copyright (c) Microsoft Corporation.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# This pipelineymlgen template creates a placeholder parameter object that shows
+# important information to the user who hit the "Run" button so they can make a
+# more informed decision about whether they should use this pipeline.
+#
+# data inputs:
+# - desc - The description text to include.
+# - output - An output file of the template. Generally a pipeline .gen.yml file
+#   will automatically populate this data.
+#
+# The value is chosen to make it seem less out of place:
+#
+# The emoji fits in with the radio selection that shows up in the Run dialog to
+# obscure the oddity of a single-option choice. The yml filename is included
+# because it's technically potentially useful and fits in, even though it's
+# likely not important.
+
+name: _info
+displayName: ${ cat "ℹ️" .desc }
+type: string
+values:
+  - ${ cat "🔵 " .output " 🔵 🔵" }
+default: ${ cat "🔵 " .output " 🔵 🔵" }


### PR DESCRIPTION
* Based on https://github.com/microsoft/go-images/pull/645
* For https://github.com/microsoft/go-lab/issues/434
* For https://github.com/microsoft/go-lab/issues/435

The main change is adding descriptions and clarifying parameters:

> <img width="1070" height="632" alt="image" src="https://github.com/user-attachments/assets/7569e14b-6163-4404-ada1-250fffb81657" />

This repository unfortunately had non-reproducing gen.yml templates, which I had to fix up:

* The meaning of an omitted `inlineelse` has been clarified and ambiguous cases are now an error, which means the `${ inlineelse }: none` branch has to be specified now or the template fails to evaluate. `none` is clearer than `{}`, so this is a nice change for that reason too.
* The wrap behavior in the yml library changed somehow, so the output of the stages template changed. It looks awkward, but it's a NOOP because of how yml wrapping works.

Our infra test suite does check for non-reproducible gen.yml templates, but CI doesn't run that suite, which will be fixed as followup.